### PR TITLE
Handle stream ID 0 in Ping frames.

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -22,6 +22,9 @@ use parking_lot::Mutex;
 use std::{fmt, sync::Arc, u32};
 
 
+pub(crate) const CONNECTION_ID: Id = Id(0);
+
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id(u32);
 


### PR DESCRIPTION
The spec states, that for Ping (and GoAway) frames 0 should be used as stream ID, so we better respond.