### PR TITLE
Send GO_AWAY frame on shutdown.

### DIFF
--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -52,7 +52,8 @@ impl Flags {
     }
 }
 
-
+/// Termination code for use with GoAway frames.
+pub const CODE_TERM: u32 = 0;
 /// Protocol error code for use with GoAway frames.
 pub const ECODE_PROTO: u32 = 1;
 /// Internal error code for use with GoAway frames.


### PR DESCRIPTION
Rename the existing `shutdown` method to `close` and make the latter flush any buffered data before closing. The new `shutdown` behaviour is merely adding a GO_AWAY frame to the pending data which is sent out on `flush` or `close`.