### PR TITLE
Add inherent poll() to Connection

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -154,7 +154,7 @@ where
             return Ok(Async::Ready(Some(stream)))
         }
         connection.on_drop(Action::None);
-        return Ok(Async::NotReady)
+        Ok(Async::NotReady)
     }
 }
 


### PR DESCRIPTION
`Stream::poll()` takes a `&mut self` which is problematic as libp2p's `StreamMuxer`s methods take immutable references. This was previously worked around in libp2p by wrapping `yamux::Connection` in an extra `Mutex`. This PR implements `poll()` as an inherent method that takes `&self` making it possible to call without a mutex from `libp2p`.
The PR retains the `Stream` impl so that code can use its convenient API.