### PR TITLE
No clear

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"
 repository = "https://github.com/paritytech/yamux"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 bytes = "0.4"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -496,6 +496,7 @@ where
 }
 
 /// A handle to a multiplexed stream.
+#[derive(Debug)]
 pub struct StreamHandle<T>
 where
     T: AsyncRead + AsyncWrite

--- a/src/frame/codec.rs
+++ b/src/frame/codec.rs
@@ -145,7 +145,7 @@ mod tests {
 
     impl Arbitrary for RawFrame {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            use frame::header::Type::*;
+            use crate::frame::header::Type::*;
             let ty = g.choose(&[Data, WindowUpdate, Ping, GoAway]).unwrap().clone();
             let len = g.gen::<u16>() as u32;
             let header = RawHeader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //! `Connection` implements `futures::Stream` yielding `StreamHandle`s for inbound connection
 //! attempts.
 
+#![feature(nll)]
+
 extern crate bytes;
 extern crate futures;
 extern crate nohash_hasher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,19 +17,6 @@
 //! `Connection` implements `futures::Stream` yielding `StreamHandle`s for inbound connection
 //! attempts.
 
-#![feature(nll)]
-
-extern crate bytes;
-extern crate futures;
-extern crate nohash_hasher;
-extern crate log;
-extern crate parking_lot;
-#[cfg(test)]
-extern crate quickcheck;
-extern crate quick_error;
-extern crate tokio_io;
-extern crate tokio_codec;
-
 mod connection;
 mod error;
 #[allow(dead_code)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -48,10 +48,25 @@ impl fmt::Display for Id {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum State {
     Open,
-    #[allow(dead_code)]
     SendClosed,
     RecvClosed,
     Closed
+}
+
+impl State {
+    pub fn can_read(self) -> bool {
+        match self {
+            State::RecvClosed | State::Closed => false,
+            _ => true
+        }
+    }
+
+    pub fn can_write(self) -> bool {
+        match self {
+            State::SendClosed | State::Closed => false,
+            _ => true
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -70,6 +85,10 @@ impl StreamEntry {
             window,
             credit
         }
+    }
+
+    pub(crate) fn state(&self) -> State {
+        self.state
     }
 
     pub(crate) fn update_state(&mut self, next: State) {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -8,13 +8,6 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-extern crate log;
-extern crate env_logger;
-extern crate futures;
-extern crate tokio;
-extern crate tokio_codec;
-extern crate yamux;
-
 use futures::{future::{self, Either, Loop}, prelude::*, stream};
 use log::{debug, error, warn};
 use std::io;


### PR DESCRIPTION
To allow streams to finish reading all of their data as well as to allow short-lived connections which start and finish within a single `poll` call, we should never clear the whole streams map, but rather have streams remove themselves one by one.