### PR TITLE
Don't attempt to remove a stream twice

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -402,7 +402,6 @@ where
             if stream.buffer.lock().len() >= self.config.max_buffer_size {
                 error!("buffer of stream {} grows beyond limit", stream_id);
                 self.reset(stream_id);
-                self.streams.remove(&stream_id);
             } else {
                 stream.window = stream.window.saturating_sub(frame.body().len() as u32);
                 stream.buffer.lock().extend(frame.body());


### PR DESCRIPTION
`reset()` already [removes the stream](https://github.com/paritytech/yamux/pull/28/files#diff-c80c453b374ae714374e0f9d9d86ba1cL484).