### PR TITLE
Make config closer to mplex

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -83,7 +83,7 @@ where
         if connection.is_dead {
             return Ok(None)
         }
-        if connection.streams.len() >= connection.config.max_num_streams {
+        if connection.streams.len() >= connection.config.max_substreams {
             error!("maximum number of streams reached");
             return Err(ConnectionError::TooManyStreams)
         }
@@ -376,7 +376,7 @@ where
                 error!("stream {} already exists", stream_id);
                 return Ok(Some(Frame::go_away(ECODE_PROTO)))
             }
-            if self.streams.len() == self.config.max_num_streams {
+            if self.streams.len() == self.config.max_substreams {
                 error!("maximum number of streams reached");
                 return Ok(Some(Frame::go_away(ECODE_INTERNAL)))
             }
@@ -439,7 +439,7 @@ where
                 error!("stream {} already exists", stream_id);
                 return Ok(Some(Frame::go_away(ECODE_PROTO)))
             }
-            if self.streams.len() == self.config.max_num_streams {
+            if self.streams.len() == self.config.max_substreams {
                 error!("maximum number of streams reached");
                 return Ok(Some(Frame::go_away(ECODE_INTERNAL)))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,13 +62,13 @@ pub enum WindowUpdateMode {
 ///
 /// - receive window = 256 KiB
 /// - max. buffer size (per stream) = 1 MiB
-/// - max. number of streams = 8192
+/// - max. substreams = 8192
 /// - window update mode = on receive
 #[derive(Debug, Clone)]
 pub struct Config {
     pub(crate) receive_window: u32,
     pub(crate) max_buffer_size: usize,
-    pub(crate) max_num_streams: usize,
+    pub(crate) max_substreams: usize,
     pub(crate) window_update_mode: WindowUpdateMode
 }
 
@@ -77,13 +77,18 @@ impl Default for Config {
         Config {
             receive_window: DEFAULT_CREDIT,
             max_buffer_size: 1024 * 1024,
-            max_num_streams: 8192,
+            max_substreams: 8192,
             window_update_mode: WindowUpdateMode::OnReceive
         }
     }
 }
 
 impl Config {
+    /// Builds the default configuration.
+    pub fn new() -> Config {
+        Default::default()
+    }
+
     /// Set the receive window (must be >= 256 KiB).
     pub fn set_receive_window(&mut self, n: u32) -> Result<(), ()> {
         if n >= DEFAULT_CREDIT {
@@ -99,8 +104,8 @@ impl Config {
     }
 
     /// Set the max. number of streams.
-    pub fn set_max_num_streams(&mut self, n: usize) {
-        self.max_num_streams = n
+    pub fn set_max_substreams(&mut self, n: usize) {
+        self.max_substreams = n
     }
 
     /// Set the window update mode to use.


### PR DESCRIPTION
Rernames `max_num_streams` to `max_substreams` ([like mplex](https://github.com/libp2p/rust-libp2p/blob/master/muxers/mplex/src/lib.rs#L44)) and adds `Config::new()` ([mplex has this; uses `Default::default()`](https://github.com/libp2p/rust-libp2p/blob/master/muxers/mplex/src/lib.rs#L56)).

I'm not sure this is a good idea or not. I think it'd be good if different `StreamMuxer` impls try to be as similar as makes sense, to make it easy on third party devs to learn their APIs.