### PR TITLE
Fix handling of receive window.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -380,7 +380,7 @@ where
                 error!("maximum number of streams reached");
                 return Ok(Some(Frame::go_away(ECODE_INTERNAL)))
             }
-            let mut stream = StreamEntry::new(self.config.receive_window, DEFAULT_CREDIT);
+            let mut stream = StreamEntry::new(DEFAULT_CREDIT, DEFAULT_CREDIT);
             if is_finish {
                 stream.update_state(State::RecvClosed)
             }
@@ -443,7 +443,7 @@ where
                 error!("maximum number of streams reached");
                 return Ok(Some(Frame::go_away(ECODE_INTERNAL)))
             }
-            let mut stream = StreamEntry::new(self.config.receive_window, frame.header().credit());
+            let mut stream = StreamEntry::new(DEFAULT_CREDIT, frame.header().credit());
             if is_finish {
                 stream.update_state(State::RecvClosed)
             }


### PR DESCRIPTION
Except for `open_stream` always create a `StreamEntry` with a receive window = DEFAULT_CREDIT. The remote has to assume we use the default. If we configured a receive window size greater than that and use that right away we will wait for more data while the remote is waiting for our window update. The end result is a deadlock.

This commit instantiates a `StreamEntry` in `on_data` and `on_window_update` with a default receive window, matching the expectation from remote and only when sending window updates will we use the configured receive window size. The simple rule is: Only change the receive window size after telling the other end about it.