### PR TITLE
Always attempt to flush data in `process_incoming`.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -294,7 +294,6 @@ where
         if self.is_dead {
             return Ok(Async::Ready(()))
         }
-        try_ready!(self.resource.poll_flush_notify(&self.tasks, 0));
         while let Some(frame) = self.pending.pop_front() {
             trace!("{:?}: send: {:?}", self.mode, frame.header);
             if let AsyncSink::NotReady(frame) = self.resource.start_send_notify(frame, &self.tasks, 0)? {
@@ -311,7 +310,8 @@ where
             return Ok(Async::Ready(()))
         }
         loop {
-            if !self.pending.is_empty() && self.flush_pending()?.is_not_ready() {
+            try_ready!(self.resource.poll_flush_notify(&self.tasks, 0));
+            if !self.pending.is_empty() & self.flush_pending()?.is_not_ready() {
                 self.tasks.insert_current();
                 return Ok(Async::NotReady)
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -311,7 +311,7 @@ where
         }
         loop {
             try_ready!(self.resource.poll_flush_notify(&self.tasks, 0));
-            if !self.pending.is_empty() & self.flush_pending()?.is_not_ready() {
+            if !self.pending.is_empty() && self.flush_pending()?.is_not_ready() {
                 self.tasks.insert_current();
                 return Ok(Async::NotReady)
             }


### PR DESCRIPTION
Currently, if `poll_flush_notify` returns `NotReady` in `flush_pending` after we managed to start sending our pending data we will not attempt to resume flushing until more pending data has been accumulated which does not necessarily happen.

Instead, we must attempt to flush unconditionally in `process_incoming` to ensure any pending flush operation completes.