### PR TITLE
Avoid unnecessary copying of data frame bodies.

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -11,6 +11,11 @@
 use bytes::BytesMut;
 use std::collections::VecDeque;
 
+/// A sequence of `BytesMut` values.
+///
+/// `Chunks::is_empty` and `Chunks::len` consider all `BytesMut` elements and
+/// compute the total result, e.g. the length of all bytes by summing up the
+/// lengths of all `BytesMut` elements.
 #[derive(Debug)]
 pub struct Chunks {
     seq: VecDeque<BytesMut>
@@ -25,8 +30,10 @@ impl Chunks {
         self.seq.iter().all(|x| x.is_empty())
     }
 
-    pub fn len(&self) -> usize {
-        self.seq.iter().map(|x| x.len()).sum()
+    pub fn len(&self) -> Option<usize> {
+        self.seq.iter().fold(Some(0), |total, x| {
+            total.and_then(|n| n.checked_add(x.len()))
+        })
     }
 
     pub fn push(&mut self, x: BytesMut) {

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -1,0 +1,43 @@
+// Copyright 2019 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 or MIT license, at your option.
+//
+// A copy of the Apache License, Version 2.0 is included in the software as
+// LICENSE-APACHE and a copy of the MIT license is included in the software
+// as LICENSE-MIT. You may also obtain a copy of the Apache License, Version 2.0
+// at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
+// at https://opensource.org/licenses/MIT.
+
+use bytes::BytesMut;
+use std::collections::VecDeque;
+
+#[derive(Debug)]
+pub struct Chunks {
+    seq: VecDeque<BytesMut>
+}
+
+impl Chunks {
+    pub fn new() -> Self {
+        Chunks { seq: VecDeque::new() }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.seq.iter().all(|x| x.is_empty())
+    }
+
+    pub fn len(&self) -> usize {
+        self.seq.iter().map(|x| x.len()).sum()
+    }
+
+    pub fn push(&mut self, x: BytesMut) {
+        self.seq.push_back(x)
+    }
+
+    pub fn pop(&mut self) -> Option<BytesMut> {
+        self.seq.pop_front()
+    }
+
+    pub fn front_mut(&mut self) -> Option<&mut BytesMut> {
+        self.seq.front_mut()
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -399,7 +399,8 @@ where
             if is_finish {
                 stream.update_state(State::RecvClosed)
             }
-            if stream.buffer.lock().len() >= self.config.max_buffer_size {
+            let max_buffer_size = self.config.max_buffer_size;
+            if stream.buffer.lock().len().map(move |n| n >= max_buffer_size).unwrap_or(true) {
                 error!("buffer of stream {} grows beyond limit", stream_id);
                 self.reset(stream_id);
             } else {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -8,7 +8,7 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use bytes::Bytes;
+use bytes::BytesMut;
 use crate::{frame::header::{Header, RawHeader}, stream};
 use std::u32;
 
@@ -18,7 +18,7 @@ pub mod header;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawFrame {
     pub header: RawHeader,
-    pub body: Bytes
+    pub body: BytesMut
 }
 
 impl RawFrame {
@@ -39,7 +39,7 @@ pub enum GoAway {}
 #[derive(Clone, Debug)]
 pub struct Frame<T> {
     header: Header<T>,
-    body: Bytes
+    body: BytesMut
 }
 
 impl<T> Frame<T> {
@@ -51,7 +51,7 @@ impl<T> Frame<T> {
     }
 
     pub fn new(header: Header<T>) -> Frame<T> {
-        Frame { header, body: Bytes::new() }
+        Frame { header, body: BytesMut::new() }
     }
 
     pub fn header(&self) -> &Header<T> {
@@ -71,15 +71,19 @@ impl<T> Frame<T> {
 }
 
 impl Frame<Data> {
-    pub fn data(id: stream::Id, b: Bytes) -> Self {
+    pub fn data(id: stream::Id, b: BytesMut) -> Self {
         Frame {
             header: Header::data(id, b.len() as u32),
             body: b
         }
     }
 
-    pub fn body(&self) -> &Bytes {
+    pub fn body(&self) -> &BytesMut {
         &self.body
+    }
+
+    pub fn into_body(self) -> BytesMut {
+        self.body
     }
 }
 
@@ -87,7 +91,7 @@ impl Frame<WindowUpdate> {
     pub fn window_update(id: stream::Id, n: u32) -> Self {
         Frame {
             header: Header::window_update(id, n),
-            body: Bytes::new()
+            body: BytesMut::new()
         }
     }
 }
@@ -96,7 +100,7 @@ impl Frame<GoAway> {
     pub fn go_away(error: u32) -> Self {
         Frame {
             header: Header::go_away(error),
-            body: Bytes::new()
+            body: BytesMut::new()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! `Connection` implements `futures::Stream` yielding `StreamHandle`s for inbound connection
 //! attempts.
 
+mod chunks;
 mod connection;
 mod error;
 #[allow(dead_code)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -8,7 +8,7 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use bytes::BytesMut;
+use crate::chunks::Chunks;
 use parking_lot::Mutex;
 use std::{fmt, sync::Arc, u32};
 
@@ -74,14 +74,14 @@ pub(crate) struct StreamEntry {
     state: State,
     pub(crate) window: u32,
     pub(crate) credit: u32,
-    pub(crate) buffer: Arc<Mutex<BytesMut>>
+    pub(crate) buffer: Arc<Mutex<Chunks>>
 }
 
 impl StreamEntry {
     pub(crate) fn new(window: u32, credit: u32) -> Self {
         StreamEntry {
             state: State::Open,
-            buffer: Arc::new(Mutex::new(BytesMut::new())),
+            buffer: Arc::new(Mutex::new(Chunks::new())),
             window,
             credit
         }


### PR DESCRIPTION
Instead of copying bytes from incoming data frame bodies into the stream buffer just move the bodies into a queue of `BytesMut` values.