### PR TITLE
No redundant reset

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -504,7 +504,11 @@ where
     }
 
     fn reset(&mut self, id: stream::Id) {
-        if self.streams.remove(&id).is_none() {
+        if let Some(stream) = self.streams.remove(&id) {
+            if stream.state() == State::Closed {
+                return
+            }
+        } else {
             return
         }
         if self.is_dead {
@@ -555,8 +559,7 @@ where
     fn drop(&mut self) {
         let mut inner = self.connection.inner.lock();
         debug!("{}: {}: dropping stream", inner.id, self.id);
-        inner.reset(self.id);
-        inner.streams.remove(&self.id);
+        inner.reset(self.id)
     }
 }
 


### PR DESCRIPTION
Check the stream state in `Connection::reset`. If `Closed` it means that either the connection is dead, or a reset frame has already been received for this stream, hence it is not necessary to send out a new one.

On top of #36.