### PR TITLE
Randomise and expand integration tests.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ tokio-io = "0.1"
 
 [dev-dependencies]
 env_logger = "0.5"
-quickcheck = "0.6"
+quickcheck = "0.8"
 tokio = "0.1"
 tokio-codec = "0.1"

--- a/src/frame/codec.rs
+++ b/src/frame/codec.rs
@@ -141,12 +141,14 @@ impl Decoder for HeaderCodec {
 mod tests {
     use bytes::BytesMut;
     use quickcheck::{Arbitrary, Gen, quickcheck};
+    use rand::Rng;
+    use rand::seq::SliceRandom;
     use super::*;
 
     impl Arbitrary for RawFrame {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
             use crate::frame::header::Type::*;
-            let ty = g.choose(&[Data, WindowUpdate, Ping, GoAway]).unwrap().clone();
+            let ty = [Data, WindowUpdate, Ping, GoAway].choose(g).unwrap().clone();
             let len = g.gen::<u16>() as u32;
             let header = RawHeader {
                 version: Version(g.gen()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod stream;
 
 pub use crate::connection::{Connection, Mode, StreamHandle};
 pub use crate::error::{DecodeError, ConnectionError};
+pub use crate::stream::State;
 
 pub(crate) const DEFAULT_CREDIT: u32 = 256 * 1024; // as per yamux specification
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -8,97 +8,191 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use futures::{future::{self, Either, Loop}, prelude::*, stream};
-use log::{debug, error, warn};
+use bytes::Bytes;
+use futures::{future::{self, Either, Loop}, prelude::*};
+use log::{debug, error};
+use quickcheck::*;
+use rand::Rng;
+use std::fmt::{Debug, Display};
 use std::io;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use tokio::{net::{TcpListener, TcpStream}, runtime::Runtime};
-use tokio_codec::{BytesCodec, Framed};
+use tokio_codec::{BytesCodec, Framed, Encoder, Decoder};
 use yamux::{ConnectionError, Config, Connection, Mode};
 
-fn server_conn(addr: &str, cfg: Config) -> impl Future<Item=Connection<TcpStream>, Error=()> {
-    TcpListener::bind(&addr.parse().unwrap())
-        .unwrap()
-        .incoming()
-        .map(move |sock| Connection::new(sock, cfg.clone(), Mode::Server))
+#[test]
+fn prop_send_receive() {
+    let _ = env_logger::try_init();
+
+    fn prop(msgs: Vec<Msg>) -> TestResult {
+        if msgs.is_empty() {
+            return TestResult::discard()
+        }
+        let (l, a) = bind();
+        let cfg = Config::default();
+        let codec = BytesCodec::new();
+        let server = server(cfg.clone(), l).and_then(move |c| repeat_echo(c, codec, 1));
+        let num_requests = msgs.len();
+        let iter = msgs.into_iter().map(Bytes::from);
+        let stream = iter.clone();
+        let client = client(cfg, a).and_then(move |c| loop_send_recv(c, codec, stream));
+        let responses = run(server, client);
+        TestResult::from_bool(
+            responses.len() == num_requests &&
+            responses.into_iter().map(|m| m.freeze()).eq(iter))
+    }
+
+    // A single run with up to QUICKCHECK_GENERATOR_SIZE messages
+    QuickCheck::new()
+        .tests(1)
+        .quickcheck(prop as fn(_) -> _);
+}
+
+#[test]
+fn prop_max_streams() {
+    let _ = env_logger::try_init();
+
+    fn prop(n: usize) -> bool {
+        let (l, a) = bind();
+        let mut cfg = Config::default();
+        let max_streams = n % 100;
+        cfg.set_max_num_streams(max_streams);
+        let codec = BytesCodec::new();
+        let server = server(cfg.clone(), l).and_then(move |c| repeat_echo(c, codec, 1));
+        let client = client(cfg, a).and_then(move |conn| {
+            Ok((0 .. max_streams + 1).fold(vec![], |mut v, _|
+                match conn.open_stream() {
+                    Ok(Some(stream)) => { v.push(stream); v },
+                    _ => v
+                }))
+            });
+        let num_streams = run(server, client).len();
+        num_streams == max_streams
+    }
+
+    quickcheck(prop as fn(_) -> _);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Utilities
+
+#[derive(Clone, Debug)]
+struct Msg(Vec<u8>);
+
+impl From<Msg> for Bytes {
+    fn from(m: Msg) -> Bytes {
+        m.0.into()
+    }
+}
+
+impl Arbitrary for Msg {
+    fn arbitrary<G: Gen>(g: &mut G) -> Msg {
+        let n: usize = g.gen_range(1, 100);
+        let mut v = Vec::with_capacity(n);
+        for _ in 0..n { v.push(g.gen()) }
+        Msg(v)
+    }
+}
+
+fn bind() -> (TcpListener, SocketAddr) {
+    let i = Ipv4Addr::new(127, 0, 0, 1);
+    let s = SocketAddr::V4(SocketAddrV4::new(i, 0));
+    let l = TcpListener::bind(&s).unwrap();
+    let a = l.local_addr().unwrap();
+    (l, a)
+}
+
+fn server(c: Config, l: TcpListener) -> impl Future<Item = Connection<TcpStream>, Error = ()> {
+    l.incoming()
+        .map(move |sock| Connection::new(sock, c.clone(), Mode::Server))
         .into_future()
         .map_err(|(e, _rem)| error!("accept failed: {}", e))
         .and_then(|(maybe, _rem)| maybe.ok_or(()))
 }
 
-fn client_conn(addr: &str, cfg: Config) -> impl Future<Item=Connection<TcpStream>, Error=()> {
-    let address = addr.parse().unwrap();
-    TcpStream::connect(&address)
+fn client(c: Config, a: SocketAddr) -> impl Future<Item = Connection<TcpStream>, Error = ()> {
+    TcpStream::connect(&a)
         .map_err(|e| error!("connect failed: {}", e))
-        .map(move |sock| Connection::new(sock, cfg, Mode::Client))
+        .map(move |sock| Connection::new(sock, c, Mode::Client))
 }
 
-#[test]
-fn connect_two_endpoints() {
-    let _ = env_logger::try_init();
-    let cfg = Config::default();
-    let mut rt = Runtime::new().unwrap();
+/// Read `n` frames from each incoming stream on the connection and echo them
+/// back to the sender, logging any connection errors.
+fn repeat_echo<D>(c: Connection<TcpStream>, d: D, n: u64) -> impl Future<Item = (), Error = ()>
+where
+    D: Encoder<Error = io::Error> + Decoder<Error = io::Error> + Copy,
+    <D as Encoder>::Item: From<<D as Decoder>::Item>
+{
+    c.for_each(move |stream| {
+        let (stream_out, stream_in) = Framed::new(stream, d).split();
+        stream_in
+            .take(n)
+            .map(|frame_in| frame_in.into())
+            .forward(stream_out)
+            .map_err(|e| ConnectionError::Io(e))
+            .map(|_| ())
+    }).map_err(|e| error!("S: connection error: {}", e))
+}
 
-    let echo_stream_ids = server_conn("127.0.0.1:12345", cfg.clone())
-        .and_then(|conn| {
-            conn.for_each(|stream| {
-                debug!("S: new stream");
-                let body = vec![
-                    "Hi client!".as_bytes().into(),
-                    "See you!".as_bytes().into()
-                ];
-                let codec = Framed::new(stream, BytesCodec::new());
-                codec.send_all(stream::iter_ok::<_, io::Error>(body))
-                    .map(|_| ())
-                    .or_else(|e| match e.kind() {
-                        io::ErrorKind::WriteZero => {
-                            warn!("failed to complete stream write");
-                            Ok(())
-                        }
-                        _ => {
-                            error!("S: stream error: {}", e);
-                            Err(ConnectionError::Io(e))
-                        }
-                    })
-            })
-            .map_err(|e| error!("S: connection error: {}", e))
-        });
-
-    let client = client_conn("127.0.0.1:12345", cfg).and_then(|conn| {
-        future::loop_fn(0, move |i| {
-            match conn.open_stream() {
-                Ok(Some(stream)) => {
-                    let codec = Framed::new(stream, BytesCodec::new());
-                    let future = codec.send("Hi server!".as_bytes().into())
-                        .map_err(|e| error!("C: send error: {}", e))
-                        .and_then(move |codec| {
-                            codec.for_each(|data| {
-                                debug!("C: received {:?}", data);
-                                Ok(())
-                            })
-                            .map_err(|e| error!("C: stream error: {}", e))
-                            .and_then(move |()| {
-                                if i == 2 {
-                                    debug!("C: done");
-                                    Ok(Loop::Break(()))
-                                } else {
-                                    Ok(Loop::Continue(i + 1))
-                                }
-                            })
-                        });
-                    Either::A(future)
-                }
-                Ok(None) => {
-                    debug!("eof");
-                    Either::B(future::ok(Loop::Break(())))
-                }
-                Err(e) => {
-                    error!("C: connection error: {}", e);
-                    Either::B(future::ok(Loop::Break(())))
-                }
+/// Sequentially send a sequence of messages on a connection, with a new
+/// stream for each message, collecting the responses.
+fn loop_send_recv<D,I>(c: Connection<TcpStream>, d: D, i: I)
+    -> impl Future<Item = Vec<<D as Decoder>::Item>, Error = ()>
+where
+    I: Iterator<Item = <D as Encoder>::Item>,
+    D: Encoder + Decoder + Copy,
+    <D as Encoder>::Item: Debug,
+    <D as Encoder>::Error: Debug + Display,
+    <D as Decoder>::Item: Debug,
+    <D as Decoder>::Error: Debug + Display,
+{
+    future::loop_fn((vec![], i), move |(mut v, mut it)| {
+        let msg = match it.next() {
+            Some(msg) => {
+                debug!("C: sending: {:?}", msg);
+                msg
             }
-        })
-    });
-
-    rt.spawn(echo_stream_ids);
-    rt.block_on(client).unwrap();
+            None => {
+                debug!("C: done");
+                return Either::B(future::ok(Loop::Break((v, it))))
+            }
+        };
+        match c.open_stream() {
+            Ok(Some(stream)) => {
+                debug!("C: new stream: {:?}", stream);
+                let codec = Framed::new(stream, d);
+                let future = codec.send(msg)
+                    .map_err(|e| error!("C: send error: {}", e))
+                    .and_then(move |codec| {
+                        codec.collect().and_then(move |data| {
+                            debug!("C: received {:?}", data);
+                            v.extend(data);
+                            Ok(Loop::Continue((v, it)))
+                        })
+                        .map_err(|e| error!("C: receive error: {}", e))
+                    });
+                Either::A(future)
+            }
+            Ok(None) => {
+                debug!("eof");
+                Either::B(future::ok(Loop::Break((v, it))))
+            }
+            Err(e) => {
+                error!("C: connection error: {}", e);
+                Either::B(future::ok(Loop::Break((v, it))))
+            }
+        }
+    }).map(|(v, _)| v)
 }
+
+fn run<R,S,C>(server: S, client: C) -> R
+where
+    S: Future<Item = (), Error = ()> + Send + 'static,
+    C: Future<Item = R, Error = ()> + Send + 'static,
+    R: Send + 'static
+{
+    let mut rt = Runtime::new().unwrap();
+    rt.spawn(server);
+    client.wait().unwrap()
+}
+


### PR DESCRIPTION
  Includes:

  * Using OS-assigned, free port numbers.
  * Randomising test inputs.
  * Extracting reusable functionality.
  * Begin extending integration test coverage, e.g. for  https://github.com/paritytech/yamux/pull/36. More tests may follow.

Thereby upgrade the `quickcheck` dependency. 