### PR TITLE
Fix logic error related to `read_after_close`.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -632,7 +632,7 @@ where
                 }
             }
 
-            if inner.config.read_after_close && inner.status != ConnStatus::Open {
+            if inner.status != ConnStatus::Open {
                 return Ok(0)
             }
 


### PR DESCRIPTION
`read_after_close` is not relevant here. If the connection is not open we should not attempt to read from it anymore once the buffer has been exhausted, regardless of this setting.