### PR TITLE
Limit pending buffer and fix test.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,9 @@ quick_error! {
         TooManyStreams {
             display("maximum number of streams exhausted")
         }
+        TooManyPendingFrames {
+            display("maximum number of pending streams reached")
+        }
         #[doc(hidden)]
         __Nonexhaustive
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,7 +57,7 @@ quick_error! {
             display("maximum number of streams exhausted")
         }
         TooManyPendingFrames {
-            display("maximum number of pending streams reached")
+            display("maximum number of pending frames reached")
         }
         #[doc(hidden)]
         __Nonexhaustive

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,8 @@ impl Config {
         self.max_num_streams = n
     }
 
-    /// Set the max. number of pending frames, i.e. frames
-    /// which are to be sent to the remote, but can not right
-    /// away and need to be buffered.
+    /// Set the max. number of pending frames, i.e. outgoing
+    /// frames which have not yet been sent.
     pub fn set_max_pending_frames(&mut self, n: usize) {
         self.max_pending_frames = n
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub enum WindowUpdateMode {
 /// - receive window = 256 KiB
 /// - max. buffer size (per stream) = 1 MiB
 /// - max. number of streams = 8192
+/// - max. pending frames = 2048
 /// - window update mode = on receive
 /// - read after close = true
 #[derive(Debug, Clone)]
@@ -72,6 +73,7 @@ pub struct Config {
     pub(crate) receive_window: u32,
     pub(crate) max_buffer_size: usize,
     pub(crate) max_num_streams: usize,
+    pub(crate) max_pending_frames: usize,
     pub(crate) window_update_mode: WindowUpdateMode,
     pub(crate) read_after_close: bool
 }
@@ -82,6 +84,7 @@ impl Default for Config {
             receive_window: DEFAULT_CREDIT,
             max_buffer_size: 1024 * 1024,
             max_num_streams: 8192,
+            max_pending_frames: 2048,
             window_update_mode: WindowUpdateMode::OnReceive,
             read_after_close: true
         }
@@ -107,6 +110,14 @@ impl Config {
     pub fn set_max_num_streams(&mut self, n: usize) {
         self.max_num_streams = n
     }
+
+    /// Set the max. number of pending frames, i.e. frames
+    /// which are to be sent to the remote, but can not right
+    /// away and need to be buffered.
+    pub fn set_max_pending_frames(&mut self, n: usize) {
+        self.max_pending_frames = n
+    }
+
 
     /// Set the window update mode to use.
     pub fn set_window_update_mode(&mut self, m: WindowUpdateMode) {

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -56,7 +56,6 @@ fn roundtrip(addr: SocketAddr, nstreams: u64, data: Bytes) {
 }
 
 #[test]
-#[ignore] // FIXME
 fn concurrent_streams() {
     let data = std::iter::repeat(0x42u8).take(100 * 1024).collect::<Vec<_>>().into();
     roundtrip("127.0.0.1:9000".parse().expect("valid address"), 1000, data)


### PR DESCRIPTION
The cause for the sometimes not terminating test was that both endpoints
attempt to finish a writing operation and would not continue reading
from the socket. We must--as much as possible--continue reading, even
when we can not complete a write operation to prevent deadlock.

Since we buffer pending frames, which are meant to be delivered to the
remote and we make progress even if we can not write, we must limit the
resource growth of the pending frames buffer. This PR adds a new setting
`max_pending_frames` to do just that.