### PR TITLE
Fix missed task notifications.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -344,7 +344,7 @@ where
         Ok(())
     }
 
-    // nb. Always registers the current task with the `self.tasks` notifier.
+    // Always registers the current task with the `self.tasks` notifier.
     fn flush_pending(&mut self) -> Poll<(), ConnectionError> {
         // The current task must be registered with `self.tasks` *before*
         // calling `start_send_notify` or `poll_flush_notify` on the underlying
@@ -368,9 +368,10 @@ where
 
     fn process_incoming(&mut self) -> Poll<(), ConnectionError> {
         loop {
-            // nb. Registers the current task with `self.tasks`. The current task
-            // must be registered with `self.tasks` *before* calling `poll_stream_notify`
-            // on the underlying resource, in order not to risk missing a notification.
+            // Relies on `flush_pending` always registering the current task with `self.tasks`.
+            // The current task must be registered with `self.tasks` *before* calling
+            // `poll_stream_notify` on the underlying resource, in order not to risk missing
+            // a notification.
             self.flush_pending()?;
             match self.resource.poll_stream_notify(&self.tasks, 0)? {
                 Async::Ready(Some(frame)) => {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -115,12 +115,14 @@ where
             connection.on_drop(Action::None);
             return Ok(Async::NotReady)
         }
+        // Make sure the current task is registered before calling
+        // `close_notify`, in order not to risk missing a notification.
+        connection.tasks.insert_current();
         let result = {
             let c = &mut *connection;
             c.resource.close_notify(&c.tasks, 0)?
         };
         if result.is_not_ready() {
-            connection.tasks.insert_current();
             connection.on_drop(Action::None)
         }
         Ok(result)


### PR DESCRIPTION
This is based on a former branch from @twittner that adds some benchmarks which used to stall on the current implementation. This PR is mostly for historical and informational purposes as the new implementation will supersede it shortly. The problem was diagnosed as the following:

If `poll_stream_notify`, `start_send_notify` or `poll_flush_notify` on a `Spawn` are called prior to registering the current task with `self.tasks`, a notification may be missed. I.e. `self.tasks` may be notified *before* the `NotReady` result is returned, making it unsafe to insert the current task only upon receiving `NotReady` from these functions.

This was observed in stalling benchmarks with concurrent streams. In particular, if these benchmarks stalled, they always stalled on receiving the last frame of the last stream, because a task notification from `poll_stream_notify` was missed. As long as there is more traffic, this problem is usually "papered over" by subsequent task wakeups for further data, but on the last frame of the last stream, there are no more notifications as there is no more incoming data on the connection, hence *if* the benchmarks stalled, it was always on the last frame of the last stream.

This PR remedies the problem by ensuring that the current task is always registered with `self.tasks` before calling these functions. This may result in some redundant notifications but avoids missing any. If someone sees another, more granular or otherwise better solution to the problem, please comment.

Also includes a small fix for not sending window updates when receiving a frame that signals a `FIN`, i.e. that no more data is coming.