### PR TITLE
Comment to warn future developers a double lock when unwinding

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -157,6 +157,8 @@ where
                 } else {
                     continue
                 };
+            // The following code before return shall not panic,
+            // or else a double lock will happen when unwinding.
             connection.on_drop(Action::None);
             return Ok(Async::Ready(Some(stream)))
         }


### PR DESCRIPTION
I checked all the execution paths on the intermediate code from your repository for double lock.
I found one path that may trigger a double lock.
https://github.com/paritytech/yamux/blob/6dd0a5affdd07c4602b2f004836e5a5dacfad165/src/connection.rs#L143-L162
The first lock happens on [L144](https://github.com/paritytech/yamux/blob/6dd0a5affdd07c4602b2f004836e5a5dacfad165/src/connection.rs#L144). Then on [L156](https://github.com/paritytech/yamux/blob/6dd0a5affdd07c4602b2f004836e5a5dacfad165/src/connection.rs#L156), a stream is created from a cloned self connection, which in fact clones the inner Arc. Now the stream holds a ptr to the Inner of connection!
https://github.com/paritytech/yamux/blob/master/src/connection.rs#L62
If any panic happens on [L160](https://github.com/paritytech/yamux/blob/6dd0a5affdd07c4602b2f004836e5a5dacfad165/src/connection.rs#L160)
then stack unwinds and the drop fn of stream will be called,
https://github.com/paritytech/yamux/blob/6dd0a5affdd07c4602b2f004836e5a5dacfad165/src/connection.rs#L616-L619
The second lock happens on [L617](https://github.com/paritytech/yamux/blob/6dd0a5affdd07c4602b2f004836e5a5dacfad165/src/connection.rs#L617).
This breaches the Mutex poison mechanism of Rust to avoid dead lock on panic.
I know it is almost impossible to trigger panic on fn on_drop() for now. 
But we cannot guarantee that new logic will not be inserted between ctor of stream and return in the future. 
Therefore, I think it is necessary to add such a comment just in case, so as to warn the future developers never add code that may panic into this area, or else a double lock may happen when unwinding. 

I wrote a toy program to verify this, which will cause double-lock on panic.
```
use std::sync::{Arc, Mutex};
  
struct Stream {
    connection: Arc<Mutex<i32>>,
}

impl Stream {
    fn new(mu: Arc<Mutex<i32>>) -> Stream {
        Stream {connection: mu}
    }
}

impl Drop for Stream {
    fn drop(&mut self) {
        println!("enter drop of stream");
        println!("{:?}", self.connection.lock().unwrap());
        println!("after drop of stream");
    }
}

fn may_panic() -> ! {
    panic!();
}

fn bar() -> Stream {
    let mu = Arc::new(Mutex::new(1));

    let a = mu.lock().unwrap();
    println!("{:?}", a);

    let st = Stream::new(mu.clone());

    may_panic();

    return st;
}

fn main() {
    let _st = bar();
}
```