### PR TITLE
Update to futures-0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,16 @@ repository = "https://github.com/paritytech/yamux"
 readme = "README.md"
 edition = "2018"
 
+[features]
+# Opt-in feature which allows reading data into read buffers without
+# having to initialise them first. Use only if you are certain that
+# your `AsyncRead` implementation only writes to the given buffer and
+# never reads from it.
+use_unitialised_read_buffer = []
+
 [dependencies]
 bytes = "0.4.12"
-futures-preview = "0.3.0-alpha.19"
-futures_codec = "0.3"
+futures = "0.3.1"
 log = "0.4.8"
 nohash-hasher = "0.1.2"
 parking_lot = "0.9"
@@ -20,11 +26,10 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-async-std = "0.99"
+async-std = "0.99.12"
 criterion = "0.3"
-futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
+futures_codec = "0.3.1"
 quickcheck = "0.9"
-tokio = "0.2.0-alpha.6"
 
 [[bench]]
 name = "concurrent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,6 @@ repository = "https://github.com/paritytech/yamux"
 readme = "README.md"
 edition = "2018"
 
-[features]
-# Opt-in feature which allows reading data into read buffers without
-# having to initialise them first. Use only if you are certain that
-# your `AsyncRead` implementation only writes to the given buffer and
-# never reads from it.
-use_unitialised_read_buffer = []
-
 [dependencies]
 bytes = "0.4.12"
 futures = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-async-std = "0.99.12"
+async-std = "1.0"
 criterion = "0.3"
 futures_codec = "0.3.1"
 quickcheck = "0.9"

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -20,7 +20,7 @@ criterion_group!(benches, concurrent);
 criterion_main!(benches);
 
 #[derive(Copy, Clone)]
-struct Params { streams: u64, messages: u64 }
+struct Params { streams: usize, messages: usize }
 
 impl fmt::Debug for Params {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -42,10 +42,8 @@ fn concurrent(c: &mut Criterion) {
     let data0 = Bytes::from(vec![0x42; 4096]);
     let data1 = data0.clone();
     let data2 = data0.clone();
-    let data3 = data0.clone();
-    let data4 = data0.clone();
 
-    c.bench_function_over_inputs("one by one (async-std)", move |b, &&params| {
+    c.bench_function_over_inputs("one by one", move |b, &&params| {
             let data = data1.clone();
             b.iter(move || {
                 task::block_on(roundtrip(params.streams, params.messages, data.clone(), false))
@@ -53,35 +51,17 @@ fn concurrent(c: &mut Criterion) {
         },
         params);
 
-    c.bench_function_over_inputs("all at once (async-std)", move |b, &&params| {
+    c.bench_function_over_inputs("all at once", move |b, &&params| {
             let data = data2.clone();
             b.iter(move || {
                 task::block_on(roundtrip(params.streams, params.messages, data.clone(), true))
             })
         },
         params);
-
-    c.bench_function_over_inputs("one by one (tokio)", move |b, &&params| {
-            let data = data3.clone();
-            let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-            b.iter(move || {
-                rt.block_on(roundtrip_tokio(params.streams, params.messages, data.clone(), false))
-            })
-        },
-        params);
-
-    c.bench_function_over_inputs("all at once (tokio)", move |b, &&params| {
-            let data = data4.clone();
-            let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-            b.iter(move || {
-                rt.block_on(roundtrip_tokio(params.streams, params.messages, data.clone(), true))
-            })
-        },
-        params);
 }
 
-async fn roundtrip(nstreams: u64, nmessages: u64, data: Bytes, send_all: bool) {
-    let msg_len = data.len() as u64;
+async fn roundtrip(nstreams: usize, nmessages: usize, data: Bytes, send_all: bool) {
+    let msg_len = data.len();
     let (server, client) = Endpoint::new();
     let server = server.into_async_read();
     let client = client.into_async_read();
@@ -113,84 +93,21 @@ async fn roundtrip(nstreams: u64, nmessages: u64, data: Bytes, send_all: bool) {
             let (mut os, mut is) = Framed::new(stream, LengthCodec).split();
             if send_all {
                 // Send `nmessages` messages and receive `nmessages` messages.
-                os.send_all(&mut stream::iter(iter::repeat(data).take(u64_as_usize(nmessages))))
+                os.send_all(&mut stream::repeat(data).map(Ok).take(nmessages))
                     .await
                     .expect("send_all");
                 os.close().await.expect("close");
-                let n = is.try_fold(0, |n, d| future::ready(Ok(n + d.len() as u64)))
+                let n = is.try_fold(0, |n, d| future::ready(Ok(n + d.len())))
                     .await
                     .expect("try_fold");
                 tx.unbounded_send(n).expect("unbounded_send")
             } else {
                 // Send and receive `nmessages` messages.
                 let mut n = 0;
-                for m in iter::repeat(data).take(u64_as_usize(nmessages)) {
+                for m in iter::repeat(data).take(nmessages) {
                     os.send(m).await.expect("send");
                     if let Some(d) = is.try_next().await.expect("receive") {
-                        n += d.len() as u64
-                    } else {
-                        break
-                    }
-                }
-                os.close().await.expect("close");
-                tx.unbounded_send(n).expect("unbounded_send");
-            }
-        });
-    }
-
-    let n = rx.take(nstreams).fold(0, |acc, n| future::ready(acc + n)).await;
-    assert_eq!(n, nstreams * nmessages * msg_len);
-    ctrl.close().await.expect("close")
-}
-
-async fn roundtrip_tokio(nstreams: u64, nmessages: u64, data: Bytes, send_all: bool) {
-    let msg_len = data.len() as u64;
-    let (server, client) = Endpoint::new();
-    let server = server.into_async_read();
-    let client = client.into_async_read();
-
-    let server = async move {
-        yamux::into_stream(Connection::new(server, Config::default(), Mode::Server))
-            .try_for_each_concurrent(None, |stream| async {
-                let (os, is) = Framed::new(stream, LengthCodec).split();
-                is.forward(os).await?;
-                Ok(())
-            })
-            .await
-            .expect("server works")
-    };
-
-    tokio::spawn(server);
-
-    let (tx, rx) = mpsc::unbounded();
-    let conn = Connection::new(client, Config::default(), Mode::Client);
-    let mut ctrl = conn.control();
-    tokio::spawn(yamux::into_stream(conn).for_each(|_| future::ready(())));
-
-    for _ in 0 .. nstreams {
-        let data = data.clone();
-        let tx = tx.clone();
-        let mut ctrl = ctrl.clone();
-        tokio::spawn(async move {
-            let stream = ctrl.open_stream().await.expect("open stream");
-            let (mut os, mut is) = Framed::new(stream, LengthCodec).split();
-            if send_all {
-                // Send `nmessages` messages and receive `nmessages` messages.
-                os.send_all(&mut stream::iter(iter::repeat(data).take(u64_as_usize(nmessages))))
-                    .await
-                    .expect("send_all");
-                os.close().await.expect("close");
-                let n = is.try_fold(0, |n, d| future::ready(Ok(n + d.len() as u64)))
-                    .await
-                    .expect("try_fold");
-                tx.unbounded_send(n).expect("unbounded_send")
-            } else {
-                // Send and receive `nmessages` messages.
-                let mut n = 0;
-                for m in iter::repeat(data).take(u64_as_usize(nmessages)) {
-                    os.send(m).await.expect("send");
-                    if let Some(d) = is.try_next().await.expect("receive") {
-                        n += d.len() as u64
+                        n += d.len()
                     } else {
                         break
                     }
@@ -259,9 +176,3 @@ impl AsyncWrite for Endpoint {
             .map_err(|_| io::ErrorKind::ConnectionAborted.into())
     }
 }
-
-#[cfg(any(target_pointer_width = "64"))]
-const fn u64_as_usize(a: u64) -> usize {
-    a as usize
-}
-

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -9,12 +9,13 @@
 // at https://opensource.org/licenses/MIT.
 
 pub mod header;
+mod io;
 
-use bytes::{Bytes, BytesMut};
-use futures_codec::{BytesCodec, Decoder, Encoder};
-use header::{Header, HeaderDecodeError, StreamId, Data, WindowUpdate, GoAway};
-use std::{convert::TryInto, fmt, io, num::TryFromIntError};
-use thiserror::Error;
+use bytes::Bytes;
+use header::{Header, StreamId, Data, WindowUpdate, GoAway};
+use std::{convert::TryInto, num::TryFromIntError};
+
+pub use io::{Io, FrameDecodeError};
 
 /// A Yamux message frame consisting of header and body.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -96,139 +97,6 @@ impl Frame<GoAway> {
             header: Header::internal_error(),
             body: Bytes::new()
         }
-    }
-}
-
-/// A decoder and encoder of message frames.
-pub struct Codec {
-    header_codec: header::Codec,
-    body_codec: BytesCodec,
-    header: Option<header::Header<()>>
-}
-
-impl fmt::Debug for Codec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Codec")
-            .field("header", &self.header)
-            .finish()
-    }
-}
-
-impl Codec {
-    /// Create a codec which accepts frames up to the given max. body size.
-    pub fn new(max_body_len: usize) -> Codec {
-        Codec {
-            header_codec: header::Codec::new(max_body_len),
-            body_codec: BytesCodec {},
-            header: None
-        }
-    }
-}
-
-impl Encoder for Codec {
-    type Item = Frame<()>;
-    type Error = io::Error;
-
-    fn encode(&mut self, frame: Self::Item, bytes: &mut BytesMut) -> Result<(), Self::Error> {
-        let header = self.header_codec.encode(&frame.header);
-        bytes.extend_from_slice(&header);
-        Ok(self.body_codec.encode(frame.body, bytes)?)
-    }
-}
-
-impl Decoder for Codec {
-    type Item = Frame<()>;
-    type Error = FrameDecodeError;
-
-    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if self.header.is_none() {
-            if src.len() < header::HEADER_SIZE {
-                return Ok(None)
-            }
-            let mut b: [u8; header::HEADER_SIZE] = [0; header::HEADER_SIZE];
-            b.copy_from_slice(&src.split_to(header::HEADER_SIZE));
-            self.header = Some(self.header_codec.decode(b)?)
-        }
-
-        if let Some(header) = self.header.take() {
-            if header.tag() != header::Tag::Data {
-                return Ok(Some(Frame::new(header)))
-            }
-            match crate::u32_as_usize(header.len().val()) {
-                0 => return Ok(Some(Frame::new(header))),
-                n if n <= src.len() =>
-                    if let Some(body) = self.body_codec.decode(&mut src.split_to(n))? {
-                        return Ok(Some(Frame { header, body }))
-                    }
-                n => {
-                    let add = n - src.len();
-                    src.reserve(add)
-                }
-            }
-            self.header = Some(header)
-        }
-
-        Ok(None)
-    }
-}
-
-/// Possible errors while decoding a message frame.
-#[derive(Debug, Error)]
-pub enum FrameDecodeError {
-    /// An I/O error.
-    #[error("i/o error: {0}")]
-    Io(#[from] io::Error),
-
-    /// Decoding the frame header failed.
-    #[error("decode error: {0}")]
-    Header(#[from] HeaderDecodeError),
-
-    #[doc(hidden)]
-    #[error("__Nonexhaustive")]
-    __Nonexhaustive
-}
-
-#[cfg(test)]
-mod tests {
-    use bytes::BytesMut;
-    use quickcheck::{Arbitrary, Gen, QuickCheck};
-    use rand::RngCore;
-    use super::*;
-
-    impl Arbitrary for Frame<()> {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let mut header: header::Header<()> = Arbitrary::arbitrary(g);
-            let body =
-                if header.tag() == header::Tag::Data {
-                    header.set_len(header.len().val() % 4096);
-                    let mut b = vec![0; crate::u32_as_usize(header.len().val())];
-                    rand::thread_rng().fill_bytes(&mut b);
-                    Bytes::from(b)
-                } else {
-                    Bytes::new()
-                };
-            Frame { header, body }
-        }
-    }
-
-    #[test]
-    fn encode_decode_identity() {
-        fn property(f: Frame<()>) -> bool {
-            let mut buf = BytesMut::with_capacity(header::HEADER_SIZE + f.body.len());
-            let mut codec = Codec::new(f.body.len());
-            if codec.encode(f.clone(), &mut buf).is_err() {
-                return false
-            }
-            if let Ok(x) = codec.decode(&mut buf) {
-                x == Some(f)
-            } else {
-                false
-            }
-        }
-
-        QuickCheck::new()
-            .tests(10_000)
-            .quickcheck(property as fn(Frame<()>) -> bool)
     }
 }
 

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -1,0 +1,191 @@
+// Copyright (c) 2019 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 or MIT license, at your option.
+//
+// A copy of the Apache License, Version 2.0 is included in the software as
+// LICENSE-APACHE and a copy of the MIT license is included in the software
+// as LICENSE-MIT. You may also obtain a copy of the Apache License, Version 2.0
+// at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
+// at https://opensource.org/licenses/MIT.
+
+use bytes::{BufMut, BytesMut};
+use crate::u32_as_usize;
+use futures::{io::BufWriter, prelude::*, ready};
+use std::{io, pin::Pin, task::{Context, Poll}};
+use super::{Frame, header::{self, HeaderDecodeError}};
+use thiserror::Error;
+
+/// When growing buffers we allocate units of `BLOCKSIZE`.
+/// We also use this value to buffer write operations.
+const BLOCKSIZE: usize = 8 * 1024;
+
+/// A [`Stream`] and writer of [`Frame`] values.
+#[derive(Debug)]
+pub struct Io<T> {
+    io: BufWriter<T>,
+    buffer: BytesMut,
+    header: Option<header::Header<()>>,
+    max_body_len: usize
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
+    pub fn new(io: T, max_frame_body_len: usize) -> Self {
+        Io {
+            io: BufWriter::with_capacity(BLOCKSIZE, io),
+            buffer: BytesMut::with_capacity(BLOCKSIZE),
+            header: None,
+            max_body_len: max_frame_body_len
+        }
+    }
+
+    pub async fn send<A>(&mut self, frame: &Frame<A>) -> io::Result<()> {
+        let header = header::encode(&frame.header);
+        self.io.write_all(&header).await?;
+        self.io.write_all(&frame.body).await
+    }
+
+    pub async fn flush(&mut self) -> io::Result<()> {
+        self.io.flush().await
+    }
+
+    pub async fn close(&mut self) -> io::Result<()> {
+        self.io.close().await
+    }
+
+    /// Try to decode a [`Frame`] from the internal buffer.
+    ///
+    /// Returns `Ok(None)` if more data is needed, otherwise some
+    /// frame or a decoding error.
+    fn decode(&mut self) -> Result<Option<Frame<()>>, FrameDecodeError> {
+        if self.header.is_none() {
+            if self.buffer.len() < header::HEADER_SIZE {
+                return Ok(None)
+            }
+            let mut b = [0u8; header::HEADER_SIZE];
+            b.copy_from_slice(&self.buffer.split_to(header::HEADER_SIZE));
+            let header = header::decode(&b)?;
+            if header.tag() != header::Tag::Data {
+                return Ok(Some(Frame::new(header)))
+            }
+            if u32_as_usize(header.len().val()) > self.max_body_len {
+                return Err(FrameDecodeError::FrameTooLarge(u32_as_usize(header.len().val())))
+            }
+            self.header = Some(header)
+        }
+
+        if let Some(header) = self.header.take() {
+            let n = u32_as_usize(header.len().val());
+            if n <= self.buffer.len() {
+                return Ok(Some(Frame { header, body: self.buffer.split_to(n).freeze() }))
+            }
+            self.header = Some(header)
+        }
+
+        Ok(None)
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Io<T> {
+    type Item = Result<Frame<()>, FrameDecodeError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.decode() {
+                Ok(Some(f)) => return Poll::Ready(Some(Ok(f))),
+                Ok(None) => {
+                    if self.buffer.remaining_mut() < BLOCKSIZE {
+                        if cfg!(feature = "use_unitialised_read_buffer") {
+                            self.buffer.reserve(BLOCKSIZE)
+                        } else {
+                            let n = self.buffer.len();
+                            self.buffer.resize(n + BLOCKSIZE, 0);
+                            unsafe { self.buffer.set_len(n) }
+                        }
+                    }
+                    unsafe {
+                        let this = &mut *self;
+                        let b = this.buffer.bytes_mut();
+                        let n = ready!(Pin::new(this.io.get_mut()).poll_read(cx, b)?);
+                        if n == 0 {
+                            let e = FrameDecodeError::Io(io::ErrorKind::UnexpectedEof.into());
+                            return Poll::Ready(Some(Err(e)))
+                        }
+                        this.buffer.advance_mut(n)
+                    }
+                }
+                Err(e) => return Poll::Ready(Some(Err(e)))
+            }
+        }
+    }
+}
+
+/// Possible errors while decoding a message frame.
+#[derive(Debug, Error)]
+pub enum FrameDecodeError {
+    /// An I/O error.
+    #[error("i/o error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Decoding the frame header failed.
+    #[error("decode error: {0}")]
+    Header(#[from] HeaderDecodeError),
+
+    /// A data frame body length is larger than the configured maximum.
+    #[error("frame body is too large ({0})")]
+    FrameTooLarge(usize),
+
+    #[doc(hidden)]
+    #[error("__Nonexhaustive")]
+    __Nonexhaustive
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use quickcheck::{Arbitrary, Gen, QuickCheck};
+    use rand::RngCore;
+    use super::*;
+
+    impl Arbitrary for Frame<()> {
+        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let mut header: header::Header<()> = Arbitrary::arbitrary(g);
+            let body =
+                if header.tag() == header::Tag::Data {
+                    header.set_len(header.len().val() % 4096);
+                    let mut b = vec![0; u32_as_usize(header.len().val())];
+                    rand::thread_rng().fill_bytes(&mut b);
+                    Bytes::from(b)
+                } else {
+                    Bytes::new()
+                };
+            Frame { header, body }
+        }
+    }
+
+    #[test]
+    fn encode_decode_identity() {
+        fn property(f: Frame<()>) -> bool {
+            async_std::task::block_on(async move {
+                let buf = Vec::with_capacity(header::HEADER_SIZE + f.body.len());
+                let mut io = Io::new(futures::io::Cursor::new(buf), f.body.len());
+                if io.send(&f).await.is_err() {
+                    return false
+                }
+                if io.flush().await.is_err() {
+                    return false
+                }
+                io.io.get_mut().set_position(0);
+                if let Ok(Some(x)) = io.try_next().await {
+                    x == f
+                } else {
+                    false
+                }
+            })
+        }
+
+        QuickCheck::new()
+            .tests(10_000)
+            .quickcheck(property as fn(Frame<()>) -> bool)
+    }
+}
+

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -94,13 +94,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Io<T> {
                 Ok(Some(f)) => return Poll::Ready(Some(Ok(f))),
                 Ok(None) => {
                     if self.buffer.remaining_mut() < BLOCKSIZE {
-                        if cfg!(feature = "use_unitialised_read_buffer") {
-                            self.buffer.reserve(BLOCKSIZE)
-                        } else {
-                            let n = self.buffer.len();
-                            self.buffer.resize(n + BLOCKSIZE, 0);
-                            unsafe { self.buffer.set_len(n) }
-                        }
+                        let n = self.buffer.len();
+                        self.buffer.resize(n + BLOCKSIZE, 0);
+                        unsafe { self.buffer.set_len(n) }
                     }
                     unsafe {
                         let this = &mut *self;

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -15,7 +15,7 @@ use futures_codec::{Framed, LengthCodec};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use yamux::{Config, Connection, Mode};
 
-async fn roundtrip(address: SocketAddr, nstreams: u64, data: Bytes) {
+async fn roundtrip(address: SocketAddr, nstreams: usize, data: Bytes) {
     let listener = TcpListener::bind(&address).await.expect("bind");
     let address = listener.local_addr().expect("local address");
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -166,7 +166,7 @@ async fn bind() -> io::Result<(TcpListener, SocketAddr)> {
 }
 
 /// For each incoming stream of `c` echo back `n` frames to the sender.
-async fn repeat_echo(c: Connection<TcpStream>, n: u64) -> Result<(), ConnectionError> {
+async fn repeat_echo(c: Connection<TcpStream>, n: usize) -> Result<(), ConnectionError> {
     let c = yamux::into_stream(c);
     c.try_for_each_concurrent(None, |stream| async {
         let (os, is) = Framed::new(stream, BytesCodec {}).split();


### PR DESCRIPTION
Updates from `futures-preview 0.3.0-alpha.19` to `futures-0.3.1` with the following changes:

- Remove `futures_codec` dependency.
- Replace `header::Codec` with `header::{encode, decode}` functions.
- Add `frame::io` module which contains the `Io` type which decodes
frames, implements `futures::stream::Stream` and also allows writing
frames (buffered) to the socket.
- Remove the `tokio` benchmarks as they are very similar to the
`async-std` ones which allows us to remove one (dev) dependency.

While `Io::send` does not perform an immediate flush we nevertheless flush frequently and leave it for another PR to optimise this aspect.
