### PR TITLE
Make `Stream::state` private to the crate.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -77,11 +77,10 @@
 //   to be merged into `tokio` and depending on this large crate is not
 //   attractive, especially given the dire situation around cargo's flag
 //   resolution.
-// - Instead of sending data over the I/O resource with `SinkExt::send` a
-//   custom send operation could be used that does not always perform an
-//   implicit flush. This also requires adding a `StreamCommand::Flush` so
-//   that `Stream`s can trigger a flush, which they would have to when they
-//   run out of credit, or else a `SinkExt::send_all` might never finish.
+// - Flushing could be optimised. This would also require adding a
+//   `StreamCommand::Flush` so that `Stream`s can trigger a flush, which
+//   they would have to when they run out of credit, or else a series of
+//   send operations might never finish.
 // - If Rust gets async destructors, the `garbage_collect()` method can be
 //   removed. Instead a `Stream` would send a `StreamCommand::Dropped(..)`
 //   or something similar and the removal logic could happen within regular

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -111,7 +111,7 @@ impl Stream {
     }
 
     /// Get this stream's state.
-    pub fn state(&self) -> State {
+    pub(crate) fn state(&self) -> State {
         self.shared().state()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ mod error;
 mod frame;
 mod pause;
 
+#[cfg(test)]
+mod tests;
+
 pub use crate::connection::{Connection, Mode, Control, State, Stream, into_stream};
 pub use crate::error::ConnectionError;
 pub use crate::frame::{FrameDecodeError, header::{HeaderDecodeError, StreamId}};


### PR DESCRIPTION
Keep the public API surface minimal. We may at some point replace the `Mutex` around `Shared` with a futures-aware lock at which point `Stream::state` would no longer be a synchronous method. As the method is not used externally yet it is best not to introduce it at this point. Since we nevertheless use this in our tests, `smoke.rs` has been moved into the crate as `src/tests.rs`.