### PR TITLE
Fix EOF handling in `Io::poll_next`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-async-std = "1.0"
+async-std = "1.1"
 criterion = "0.3"
 futures_codec = "0.3.1"
 quickcheck = "0.9"

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -103,6 +103,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Io<T> {
                         let b = this.buffer.bytes_mut();
                         let n = ready!(Pin::new(this.io.get_mut()).poll_read(cx, b)?);
                         if n == 0 {
+                            if this.header.is_none() && this.buffer.is_empty() {
+                                return Poll::Ready(None)
+                            }
                             let e = FrameDecodeError::Io(io::ErrorKind::UnexpectedEof.into());
                             return Poll::Ready(Some(Err(e)))
                         }


### PR DESCRIPTION
Currently we always error when reading 0 bytes, however the correct thing to do is to signal the end of the stream iff there are no unparsed bytes in our buffer.