### PR TITLE
Do not export `stream::State`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //! [1]: https://github.com/hashicorp/yamux/blob/master/spec.md
 
 mod chunks;
-mod connection;
 mod error;
 mod frame;
 mod pause;
@@ -31,7 +30,9 @@ mod pause;
 #[cfg(test)]
 mod tests;
 
-pub use crate::connection::{Connection, Mode, Control, State, Stream, into_stream};
+pub(crate) mod connection;
+
+pub use crate::connection::{Connection, Mode, Control, Stream, into_stream};
 pub use crate::error::ConnectionError;
 pub use crate::frame::{FrameDecodeError, header::{HeaderDecodeError, StreamId}};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@
 
 use async_std::{net::{TcpStream, TcpListener}, task};
 use bytes::Bytes;
-use crate::{Config, Connection, ConnectionError, Mode, Control, State};
+use crate::{Config, Connection, ConnectionError, Mode, Control, connection::State};
 use futures::{future, prelude::*};
 use futures_codec::{BytesCodec, Framed};
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};


### PR DESCRIPTION
A leftover from https://github.com/paritytech/yamux/pull/62.