### PR TITLE
Update to bytes-0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-bytes = "0.4.12"
+bytes = "0.5"
 futures = "0.3.1"
 log = "0.4.8"
 nohash-hasher = "0.1.2"
@@ -21,7 +21,6 @@ thiserror = "1.0"
 anyhow = "1.0"
 async-std = "1.1"
 criterion = "0.3"
-futures_codec = "0.3.1"
 quickcheck = "0.9"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-async-std = "1.1"
+async-std = "1"
 criterion = "0.3"
 quickcheck = "0.9"
 

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -8,7 +8,7 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use crate::{
     Config,
     WindowUpdateMode,
@@ -228,7 +228,7 @@ impl AsyncWrite for Stream {
             }
             let k = std::cmp::min(crate::u32_as_usize(shared.credit), buf.len());
             shared.credit = shared.credit.saturating_sub(k as u32);
-            Bytes::from(&buf[.. k])
+            Bytes::copy_from_slice(&buf[.. k])
         };
         let n = body.len();
         let frame = Frame::data(self.id, body).expect("body <= u32::MAX");

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -101,7 +101,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Io<T> {
                     unsafe {
                         let this = &mut *self;
                         let b = this.buffer.bytes_mut();
-                        let b = &mut *(b as *mut [MaybeUninit<u8>] as *mut [u8]);
+                        let b = std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b);
                         let n = ready!(Pin::new(this.io.get_mut()).poll_read(cx, b)?);
                         if n == 0 {
                             if this.header.is_none() && this.buffer.is_empty() {

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -8,10 +8,9 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use bytes::{BufMut, BytesMut};
 use crate::u32_as_usize;
 use futures::{io::BufWriter, prelude::*, ready};
-use std::{io, mem::MaybeUninit, pin::Pin, task::{Context, Poll}};
+use std::{io, pin::Pin, task::{Context, Poll}};
 use super::{Frame, header::{self, HeaderDecodeError}};
 use thiserror::Error;
 
@@ -23,7 +22,7 @@ const BLOCKSIZE: usize = 8 * 1024;
 #[derive(Debug)]
 pub struct Io<T> {
     io: BufWriter<T>,
-    buffer: BytesMut,
+    buffer: buf::Buffer,
     header: Option<header::Header<()>>,
     max_body_len: usize
 }
@@ -32,7 +31,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
     pub fn new(io: T, max_frame_body_len: usize) -> Self {
         Io {
             io: BufWriter::with_capacity(BLOCKSIZE, io),
-            buffer: BytesMut::with_capacity(BLOCKSIZE),
+            buffer: buf::Buffer::new(),
             header: None,
             max_body_len: max_frame_body_len
         }
@@ -62,7 +61,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
                 return Ok(None)
             }
             let mut b = [0u8; header::HEADER_SIZE];
-            b.copy_from_slice(&self.buffer.split_to(header::HEADER_SIZE));
+            b.copy_from_slice(self.buffer.split_to(header::HEADER_SIZE).as_ref());
             let header = header::decode(&b)?;
             if header.tag() != header::Tag::Data {
                 return Ok(Some(Frame::new(header)))
@@ -76,7 +75,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
         if let Some(header) = self.header.take() {
             let n = u32_as_usize(header.len().val());
             if n <= self.buffer.len() {
-                return Ok(Some(Frame { header, body: self.buffer.split_to(n).freeze() }))
+                let bytes = self.buffer.split_to(n).into_bytes();
+                return Ok(Some(Frame { header, body: bytes.freeze() }))
             }
             self.header = Some(header)
         }
@@ -93,28 +93,105 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Io<T> {
             match self.decode() {
                 Ok(Some(f)) => return Poll::Ready(Some(Ok(f))),
                 Ok(None) => {
-                    if self.buffer.capacity() - self.buffer.len() < BLOCKSIZE {
-                        let n = self.buffer.len();
-                        self.buffer.resize(n + BLOCKSIZE, 0);
-                        unsafe { self.buffer.set_len(n) }
+                    if self.buffer.remaining_mut() < BLOCKSIZE {
+                        self.buffer.reserve(BLOCKSIZE)
                     }
-                    unsafe {
-                        let this = &mut *self;
-                        let b = this.buffer.bytes_mut();
-                        let b = std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b);
-                        let n = ready!(Pin::new(this.io.get_mut()).poll_read(cx, b)?);
-                        if n == 0 {
+                    let this = &mut *self;
+                    let write_buffer = this.buffer.bytes_mut();
+                    match ready!(Pin::new(this.io.get_mut()).poll_read(cx, write_buffer)?) {
+                        0 => {
                             if this.header.is_none() && this.buffer.is_empty() {
                                 return Poll::Ready(None)
                             }
                             let e = FrameDecodeError::Io(io::ErrorKind::UnexpectedEof.into());
                             return Poll::Ready(Some(Err(e)))
                         }
-                        this.buffer.advance_mut(n)
+                        n => this.buffer.advance_mut(n)
                     }
                 }
                 Err(e) => return Poll::Ready(Some(Err(e)))
             }
+        }
+    }
+}
+
+mod buf {
+    use bytes::{BufMut, BytesMut};
+    use std::{mem::{self, MaybeUninit}, ptr};
+
+    /// Wrapper around `BytesMut` with a safe API.
+    #[derive(Debug)]
+    pub struct Buffer(BytesMut);
+
+    impl Buffer {
+        /// Create a fresh empty buffer.
+        pub fn new() -> Self {
+            Buffer(BytesMut::new())
+        }
+
+        /// Is this buffer empty?
+        pub fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+
+        /// Buffer length in bytes.
+        pub fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        /// The remaining write capacity of this buffer.
+        pub fn remaining_mut(&self) -> usize {
+            self.0.capacity() - self.0.len()
+        }
+
+        /// Set `self` to `self[n ..]` and return `self[.. n]`.
+        pub fn split_to(&mut self, n: usize) -> Self {
+            Buffer(self.0.split_to(n))
+        }
+
+        /// Extract the underlying storage bytes.
+        pub fn into_bytes(self) -> BytesMut {
+            self.0
+        }
+
+        /// Reserve and initialise more capacity.
+        pub fn reserve(&mut self, additional: usize) {
+            let old = self.0.capacity();
+            self.0.reserve(additional);
+            let new = self.0.capacity();
+            if new > old {
+                let b = self.0.bytes_mut();
+                unsafe {
+                    // Safe because we never read from `b` and stay within
+                    // the boundaries of `b` when writing.
+                    ptr::write_bytes(b.as_mut_ptr(), 0, b.len())
+                }
+            }
+        }
+
+        /// Get a mutable handle to the remaining write capacity.
+        pub fn bytes_mut(&mut self) -> &mut [u8] {
+            let b = self.0.bytes_mut();
+            unsafe {
+                // Safe because `reserve` always initialises memory.
+                mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b)
+            }
+        }
+
+        /// Increment the buffer length by `n` bytes.
+        pub fn advance_mut(&mut self, n: usize) {
+            assert!(n <= self.remaining_mut(), "{} > {}", n, self.remaining_mut());
+            unsafe {
+                // Safe because we have established that `n` does not exceed
+                // the remaining capacity.
+                self.0.advance_mut(n)
+            }
+        }
+    }
+
+    impl AsRef<[u8]> for Buffer {
+        fn as_ref(&self) -> &[u8] {
+            self.0.as_ref()
         }
     }
 }


### PR DESCRIPTION
Some notable changes:

- `BytesMut::bytes_mut` now returns a `&mut [MaybeUninit<u8>]` as it may contain uninitialised memory. Since we resize our buffer, which implies initialisation, we can just cast this slice to a `&mut [u8]` and use it directly.

- `BytesMut::remaining_mut` no longer gives the length of the `BytesMut::bytes_mut` as the `BufMut` implementation grows the buffer as needed. So, to figure out if we need to reserve another BLOCKSIZE chunk we now check how much capacity is left.

- `futures_codec` has been removed from tests as it has not updated to bytes-0.5. The tests now work directly with the stream as `AsyncRead` and `AsyncWrite` impl.