### PR TITLE
Allocate the whole frame body at once.

### DIFF
--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -69,6 +69,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
             if u32_as_usize(header.len().val()) > self.max_body_len {
                 return Err(FrameDecodeError::FrameTooLarge(u32_as_usize(header.len().val())))
             }
+            self.buffer.reserve(u32_as_usize(header.len().val()));
             self.header = Some(header)
         }
 


### PR DESCRIPTION
Instead of reading large bodies in `BLOCKSIZE` steps, ensure that the buffer is large enough to hold the whole body which may result in less `poll_read` calls.