### PR TITLE
Add `futures::stream::Stream` impl for `Stream`.

### DIFF
--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -69,7 +69,7 @@ async fn roundtrip(nstreams: usize, nmessages: usize, data: Bytes, send_all: boo
         yamux::into_stream(Connection::new(server, Config::default(), Mode::Server))
             .try_for_each_concurrent(None, |mut stream| async move {
                 {
-                    let (mut r, mut w) = (&mut stream).split();
+                    let (mut r, mut w) = futures::io::AsyncReadExt::split(&mut stream);
                     futures::io::copy(&mut r, &mut w).await?;
                 }
                 stream.close().await?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -109,7 +109,7 @@ use nohash_hasher::IntMap;
 use std::{fmt, sync::Arc, task::{Context, Poll}};
 
 pub use control::Control;
-pub use stream::{State, Stream};
+pub use stream::{Packet, State, Stream};
 
 /// Arbitrary limit of our internal command channels.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod tests;
 
 pub(crate) mod connection;
 
-pub use crate::connection::{Connection, Mode, Control, Stream, into_stream};
+pub use crate::connection::{Connection, Mode, Control, Packet, Stream, into_stream};
 pub use crate::error::ConnectionError;
 pub use crate::frame::{FrameDecodeError, header::{HeaderDecodeError, StreamId}};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -154,7 +154,7 @@ async fn repeat_echo(c: Connection<TcpStream>) -> Result<(), ConnectionError> {
     let c = crate::into_stream(c);
     c.try_for_each_concurrent(None, |mut stream| async move {
         {
-            let (mut r, mut w) = (&mut stream).split();
+            let (mut r, mut w) = futures::io::AsyncReadExt::split(&mut stream);
             futures::io::copy(&mut r, &mut w).await?;
         }
         stream.close().await?;


### PR DESCRIPTION
The impl produces `Packet`s which are simply newtype wrappers around `Bytes` and expose only an `AsRef<[u8]>` interface. The `futures::stream::Stream` implementation is more efficient than the
`AsyncRead` one as it does not need to copy the bytes.