### PR TITLE
Map connection resets to `ConnectionError::Closed`.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -551,6 +551,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 log::debug!("{}: socket eof", self.id);
                 Err(ConnectionError::Closed)
             }
+            Err(e) if e.io_kind() == Some(std::io::ErrorKind::ConnectionReset) => {
+                log::debug!("{}: connection reset", self.id);
+                Err(ConnectionError::Closed)
+            }
             Err(e) => {
                 log::error!("{}: socket error: {}", self.id, e);
                 Err(e)

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,17 @@ pub enum ConnectionError {
     TooManyStreams
 }
 
+impl ConnectionError {
+    /// Return the `ErrorKind` of this `ConnectionError` if it holds an I/O error.
+    pub(crate) fn io_kind(&self) -> Option<std::io::ErrorKind> {
+        match self {
+            ConnectionError::Io(e) => Some(e.kind()),
+            ConnectionError::Decode(FrameDecodeError::Io(e)) => Some(e.kind()),
+            _ => None
+        }
+    }
+}
+
 impl From<futures::channel::mpsc::SendError> for ConnectionError {
     fn from(_: futures::channel::mpsc::SendError) -> Self {
         ConnectionError::Closed


### PR DESCRIPTION
When encountering an I/O error with `ErrorKind::ConnectionReset`, map this to a `ConnectionError::Closed` value. The remote may have closed the connection and a host implementing a "half-duplex" close sequence would send us a RST when we send data because we have not noticed the close yet. By mapping this case to a `ConnectionError::Closed` error, we effectively treat this case like any other connection close.