### PR TITLE
Send `ACK`s and enable deferred `SYN`s.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -181,7 +181,7 @@ pub(crate) enum StreamCommand {
     /// A new frame should be sent to the remote.
     SendFrame(Frame<Either<Data, WindowUpdate>>),
     /// Close a stream.
-    CloseStream(StreamId, bool) // `true` => an ACK flag needs to be set
+    CloseStream { id: StreamId, ack: bool }
 }
 
 /// Possible actions as a result of incoming frame handling.
@@ -484,7 +484,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 log::trace!("{}: sending: {}", self.id, frame.header());
                 self.socket.get_mut().send(&frame).await.or(Err(ConnectionError::Closed))?
             }
-            Some(StreamCommand::CloseStream(id, ack)) => {
+            Some(StreamCommand::CloseStream { id, ack }) => {
                 log::trace!("{}: closing stream {} of {}", self.id, id, self);
                 let mut header = Header::data(id, 0);
                 header.fin();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -146,24 +146,6 @@ impl fmt::Display for Id {
     }
 }
 
-/// Indicate if a flag still needs to be set on an outbound header.
-enum Flag {
-    /// No flag needs to be set.
-    None,
-    /// The stream was opened lazily, so set the initial SYN flag.
-    Syn,
-    /// The stream still needs acknowledgement, so set the ACK flag.
-    Ack
-}
-
-/// Map entry holding a `Stream` plus metadata.
-struct StreamEntry {
-    /// The actual stream.
-    stream: Stream,
-    /// Do we need to set a flag on an outbound header?
-    flag: Flag
-}
-
 /// A Yamux connection object.
 ///
 /// Wraps the underlying I/O resource and makes progress via its
@@ -175,7 +157,7 @@ pub struct Connection<T> {
     config: Arc<Config>,
     socket: Fuse<frame::Io<T>>,
     next_id: u32,
-    streams: IntMap<u32, StreamEntry>,
+    streams: IntMap<u32, Stream>,
     control_sender: mpsc::Sender<ControlCommand>,
     control_receiver: Pausable<mpsc::Receiver<ControlCommand>>,
     stream_sender: mpsc::Sender<StreamCommand>,
@@ -199,7 +181,7 @@ pub(crate) enum StreamCommand {
     /// A new frame should be sent to the remote.
     SendFrame(Frame<Either<Data, WindowUpdate>>),
     /// Close a stream.
-    CloseStream(StreamId)
+    CloseStream(StreamId, bool) // `true` => an ACK flag needs to be set
 }
 
 /// Possible actions as a result of incoming frame handling.
@@ -451,18 +433,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                     let config = self.config.clone();
                     let sender = self.stream_sender.clone();
                     let window = self.config.receive_window;
-                    Stream::new(id, self.id, config, window, DEFAULT_CREDIT, sender)
+                    let mut stream = Stream::new(id, self.id, config, window, DEFAULT_CREDIT, sender);
+                    if self.config.lazy_open {
+                        stream.set_flag(stream::Flag::Syn)
+                    }
+                    stream
                 };
                 if reply.send(Ok(stream.clone())).is_ok() {
                     log::debug!("{}: new outbound {} of {}", self.id, stream, self);
-                    let entry = StreamEntry { stream,
-                        flag: if self.config.lazy_open {
-                            Flag::Syn
-                        } else {
-                            Flag::None
-                        }
-                    };
-                    self.streams.insert(id.val(), entry);
+                    self.streams.insert(id.val(), stream);
                 } else {
                     log::debug!("{}: open stream {} has been cancelled", self.id, id);
                     if !self.config.lazy_open {
@@ -501,17 +480,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
     /// Process a command from one of our `Stream`s.
     async fn on_stream_command(&mut self, cmd: Option<StreamCommand>) -> Result<()> {
         match cmd {
-            Some(StreamCommand::SendFrame(mut frame)) => {
-                self.set_flag(frame.header_mut());
+            Some(StreamCommand::SendFrame(frame)) => {
                 log::trace!("{}: sending: {}", self.id, frame.header());
                 self.socket.get_mut().send(&frame).await.or(Err(ConnectionError::Closed))?
             }
-            Some(StreamCommand::CloseStream(id)) => {
+            Some(StreamCommand::CloseStream(id, ack)) => {
                 log::trace!("{}: closing stream {} of {}", self.id, id, self);
                 let mut header = Header::data(id, 0);
                 header.fin();
-                let mut header = header.left();
-                self.set_flag(&mut header);
+                if ack { header.ack() }
                 let frame = Frame::new(header);
                 self.socket.get_mut().send(&frame).await.or(Err(ConnectionError::Closed))?
             }
@@ -598,8 +575,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
         let stream_id = frame.header().stream_id();
 
         if frame.header().flags().contains(header::RST) { // stream reset
-            if let Some(entry) = self.streams.get_mut(&stream_id.val()) {
-                let mut shared = entry.stream.shared();
+            if let Some(s) = self.streams.get_mut(&stream_id.val()) {
+                let mut shared = s.shared();
                 shared.update_state(self.id, stream_id, State::Closed);
                 if let Some(w) = shared.reader.take() {
                     w.wake()
@@ -632,8 +609,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
             }
             let stream = {
                 let config = self.config.clone();
+                let credit = DEFAULT_CREDIT;
                 let sender = self.stream_sender.clone();
-                Stream::new(stream_id, self.id, config, DEFAULT_CREDIT, DEFAULT_CREDIT, sender)
+                let mut stream = Stream::new(stream_id, self.id, config, credit, credit, sender);
+                stream.set_flag(stream::Flag::Ack);
+                stream
             };
             {
                 let mut shared = stream.shared();
@@ -643,13 +623,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 shared.window = shared.window.saturating_sub(frame.body_len());
                 shared.buffer.push(frame.into_body());
             }
-            let entry = StreamEntry { stream: stream.clone(), flag: Flag::Ack };
-            self.streams.insert(stream_id.val(), entry);
+            self.streams.insert(stream_id.val(), stream.clone());
             return Action::New(stream)
         }
 
-        if let Some(entry) = self.streams.get_mut(&stream_id.val()) {
-            let mut shared = entry.stream.shared();
+        if let Some(stream) = self.streams.get_mut(&stream_id.val()) {
+            let mut shared = stream.shared();
             if frame.body().len() > crate::u32_as_usize(shared.window) {
                 log::error!("{}/{}: frame body larger than window of stream", self.id, stream_id);
                 return Action::Terminate(Frame::protocol_error())
@@ -691,8 +670,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
         let stream_id = frame.header().stream_id();
 
         if frame.header().flags().contains(header::RST) { // stream reset
-            if let Some(entry) = self.streams.get_mut(&stream_id.val()) {
-                let mut shared = entry.stream.shared();
+            if let Some(s) = self.streams.get_mut(&stream_id.val()) {
+                let mut shared = s.shared();
                 shared.update_state(self.id, stream_id, State::Closed);
                 if let Some(w) = shared.reader.take() {
                     w.wake()
@@ -723,18 +702,19 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 let credit = frame.header().credit();
                 let config = self.config.clone();
                 let sender = self.stream_sender.clone();
-                Stream::new(stream_id, self.id, config, DEFAULT_CREDIT, credit, sender)
+                let mut stream = Stream::new(stream_id, self.id, config, DEFAULT_CREDIT, credit, sender);
+                stream.set_flag(stream::Flag::Ack);
+                stream
             };
             if is_finish {
                 stream.shared().update_state(self.id, stream_id, State::RecvClosed);
             }
-            let entry = StreamEntry { stream: stream.clone(), flag: Flag::Ack };
-            self.streams.insert(stream_id.val(), entry);
+            self.streams.insert(stream_id.val(), stream.clone());
             return Action::New(stream)
         }
 
-        if let Some(entry) = self.streams.get_mut(&stream_id.val()) {
-            let mut shared = entry.stream.shared();
+        if let Some(stream) = self.streams.get_mut(&stream_id.val()) {
+            let mut shared = stream.shared();
             shared.credit += frame.header().credit();
             if is_finish {
                 shared.update_state(self.id, stream_id, State::RecvClosed);
@@ -796,14 +776,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
     async fn garbage_collect(&mut self) -> Result<()> {
         let conn_id = self.id;
         let win_update_mode = self.config.window_update_mode;
-        for entry in self.streams.values_mut() {
-            if entry.stream.strong_count() > 1 {
+        for stream in self.streams.values_mut() {
+            if stream.strong_count() > 1 {
                 continue
             }
-            log::trace!("{}: removing dropped {}", conn_id, entry.stream);
-            let stream_id = entry.stream.id();
+            log::trace!("{}: removing dropped {}", conn_id, stream);
+            let stream_id = stream.id();
             let frame = {
-                let mut shared = entry.stream.shared();
+                let mut shared = stream.shared();
                 let frame = match shared.update_state(conn_id, stream_id, State::Closed) {
                     // The stream was dropped without calling `poll_close`.
                     // We reset the stream to inform the remote of the closure.
@@ -863,36 +843,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
         }
         Ok(())
     }
-
-    /// Set ACK or SYN flag if necessary.
-    ///
-    /// We check if the stream was opened lazily in which case we need to
-    /// set the initial SYN flag.
-    ///
-    /// We also check if the stream still requires acknowledgement and
-    /// set the ACK flag if true.
-    fn set_flag(&mut self, header: &mut Header<Either<Data, WindowUpdate>>) {
-        if let Some(entry) = self.streams.get_mut(&header.stream_id().val()) {
-            match entry.flag {
-                Flag::None => (),
-                Flag::Syn => {
-                    header.syn();
-                    entry.flag = Flag::None
-                }
-                Flag::Ack => {
-                    header.ack();
-                    entry.flag = Flag::None
-                }
-            }
-        }
-    }
 }
 
 impl<T> Connection<T> {
     /// Close and drop all `Stream`s and wake any pending `Waker`s.
     fn drop_all_streams(&mut self) {
-        for (id, entry) in self.streams.drain() {
-            let mut shared = entry.stream.shared();
+        for (id, s) in self.streams.drain() {
+            let mut shared = s.shared();
             shared.update_state(self.id, StreamId::new(id), State::Closed);
             if let Some(w) = shared.reader.take() {
                 w.wake()

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -368,7 +368,7 @@ impl AsyncWrite for Stream {
         } else {
             false
         };
-        let cmd = StreamCommand::CloseStream(self.id, ack);
+        let cmd = StreamCommand::CloseStream { id: self.id, ack };
         self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?;
         self.shared().update_state(self.conn, self.id, State::SendClosed);
         Poll::Ready(Ok(()))

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -16,10 +16,10 @@ use crate::{
     connection::{self, StreamCommand},
     frame::{
         Frame,
-        header::{StreamId, WindowUpdate}
+        header::{Header, StreamId, Data, WindowUpdate}
     }
 };
-use futures::{ready, channel::mpsc, io::{AsyncRead, AsyncWrite}};
+use futures::{future::Either, ready, channel::mpsc, io::{AsyncRead, AsyncWrite}};
 use parking_lot::{Mutex, MutexGuard};
 use std::{fmt, io, pin::Pin, sync::Arc, task::{Context, Poll, Waker}};
 
@@ -56,6 +56,17 @@ impl State {
     }
 }
 
+/// Indicate if a flag still needs to be set on an outbound header.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Flag {
+    /// No flag needs to be set.
+    None,
+    /// The stream was opened lazily, so set the initial SYN flag.
+    Syn,
+    /// The stream still needs acknowledgement, so set the ACK flag.
+    Ack
+}
+
 /// A multiplexed Yamux stream.
 ///
 /// Streams are created either outbound via [`crate::Control::open_stream`]
@@ -69,6 +80,7 @@ pub struct Stream {
     config: Arc<Config>,
     sender: mpsc::Sender<StreamCommand>,
     pending: Option<Frame<WindowUpdate>>,
+    flag: Flag,
     shared: Arc<Mutex<Shared>>
 }
 
@@ -104,6 +116,7 @@ impl Stream {
             config,
             sender,
             pending: None,
+            flag: Flag::None,
             shared: Arc::new(Mutex::new(Shared::new(window, credit))),
         }
     }
@@ -111,6 +124,11 @@ impl Stream {
     /// Get this stream's identifier.
     pub fn id(&self) -> StreamId {
         self.id
+    }
+
+    /// Set the flag that should be set on the next outbound frame header.
+    pub(crate) fn set_flag(&mut self, flag: Flag) {
+        self.flag = flag
     }
 
     /// Get this stream's state.
@@ -133,6 +151,7 @@ impl Stream {
             config: self.config.clone(),
             sender: self.sender.clone(),
             pending: None,
+            flag: self.flag,
             shared: self.shared.clone()
         }
     }
@@ -140,6 +159,21 @@ impl Stream {
     fn write_zero_err(&self) -> io::Error {
         let msg = format!("{}/{}: connection is closed", self.conn, self.id);
         io::Error::new(io::ErrorKind::WriteZero, msg)
+    }
+
+    /// Set ACK or SYN flag if necessary.
+    fn add_flag(&mut self, header: &mut Header<Either<Data, WindowUpdate>>) {
+        match self.flag {
+            Flag::None => (),
+            Flag::Syn => {
+                header.syn();
+                self.flag = Flag::None
+            }
+            Flag::Ack => {
+                header.ack();
+                self.flag = Flag::None
+            }
+        }
     }
 }
 
@@ -164,8 +198,9 @@ impl futures::stream::Stream for Stream {
         // Try to deliver any pending window updates first.
         if self.pending.is_some() {
             ready!(self.sender.poll_ready(cx).map_err(|_| self.write_zero_err())?);
-            let frm = self.pending.take().expect("pending.is_some()");
-            let cmd = StreamCommand::SendFrame(frm.right());
+            let mut frame = self.pending.take().expect("pending.is_some()").right();
+            self.add_flag(frame.header_mut());
+            let cmd = StreamCommand::SendFrame(frame);
             self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?
         }
 
@@ -201,7 +236,9 @@ impl futures::stream::Stream for Stream {
         let frame = Frame::window_update(self.id, self.config.receive_window);
         match self.sender.poll_ready(cx).map_err(|_| self.write_zero_err())? {
             Poll::Ready(()) => {
-                let cmd = StreamCommand::SendFrame(frame.right());
+                let mut frame = frame.right();
+                self.add_flag(frame.header_mut());
+                let cmd = StreamCommand::SendFrame(frame);
                 self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?
             }
             Poll::Pending => self.pending = Some(frame)
@@ -222,8 +259,9 @@ impl AsyncRead for Stream {
         // Try to deliver any pending window updates first.
         if self.pending.is_some() {
             ready!(self.sender.poll_ready(cx).map_err(|_| self.write_zero_err())?);
-            let frm = self.pending.take().expect("pending.is_some()");
-            let cmd = StreamCommand::SendFrame(frm.right());
+            let mut frame = self.pending.take().expect("pending.is_some()").right();
+            self.add_flag(frame.header_mut());
+            let cmd = StreamCommand::SendFrame(frame);
             self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?
         }
 
@@ -275,7 +313,9 @@ impl AsyncRead for Stream {
         let frame = Frame::window_update(self.id, self.config.receive_window);
         match self.sender.poll_ready(cx).map_err(|_| self.write_zero_err())? {
             Poll::Ready(()) => {
-                let cmd = StreamCommand::SendFrame(frame.right());
+                let mut frame = frame.right();
+                self.add_flag(frame.header_mut());
+                let cmd = StreamCommand::SendFrame(frame);
                 self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?
             }
             Poll::Pending => self.pending = Some(frame)
@@ -304,9 +344,10 @@ impl AsyncWrite for Stream {
             Bytes::copy_from_slice(&buf[.. k])
         };
         let n = body.len();
-        let frame = Frame::data(self.id, body).expect("body <= u32::MAX");
+        let mut frame = Frame::data(self.id, body).expect("body <= u32::MAX").left();
+        self.add_flag(frame.header_mut());
         log::trace!("{}/{}: write {} bytes", self.conn, self.id, n);
-        let cmd = StreamCommand::SendFrame(frame.left());
+        let cmd = StreamCommand::SendFrame(frame);
         self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?;
         Poll::Ready(Ok(n))
     }
@@ -321,7 +362,13 @@ impl AsyncWrite for Stream {
         }
         log::trace!("{}/{}: close", self.conn, self.id);
         ready!(self.sender.poll_ready(cx).map_err(|_| self.write_zero_err())?);
-        let cmd = StreamCommand::CloseStream(self.id);
+        let ack = if self.flag == Flag::Ack {
+            self.flag = Flag::None;
+            true
+        } else {
+            false
+        };
+        let cmd = StreamCommand::CloseStream(self.id, ack);
         self.sender.start_send(cmd).map_err(|_| self.write_zero_err())?;
         self.shared().update_state(self.conn, self.id, State::SendClosed);
         Poll::Ready(Ok(()))

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -50,16 +50,16 @@ impl<T> Frame<T> {
 }
 
 impl Frame<()> {
-    pub(crate) fn as_data(self) -> Frame<Data> {
-        Frame { header: self.header.as_data(), body: self.body }
+    pub(crate) fn into_data(self) -> Frame<Data> {
+        Frame { header: self.header.into_data(), body: self.body }
     }
 
-    pub(crate) fn as_window_update(self) -> Frame<WindowUpdate> {
-        Frame { header: self.header.as_window_update(), body: self.body }
+    pub(crate) fn into_window_update(self) -> Frame<WindowUpdate> {
+        Frame { header: self.header.into_window_update(), body: self.body }
     }
 
-    pub(crate) fn as_ping(self) -> Frame<Ping> {
-        Frame { header: self.header.as_ping(), body: self.body }
+    pub(crate) fn into_ping(self) -> Frame<Ping> {
+        Frame { header: self.header.into_ping(), body: self.body }
     }
 }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,7 +12,8 @@ pub mod header;
 mod io;
 
 use bytes::Bytes;
-use header::{Header, StreamId, Data, WindowUpdate, GoAway};
+use futures::future::Either;
+use header::{Header, StreamId, Data, WindowUpdate, GoAway, Ping};
 use std::{convert::TryInto, num::TryFromIntError};
 
 pub use io::{Io, FrameDecodeError};
@@ -37,11 +38,28 @@ impl<T> Frame<T> {
         &mut self.header
     }
 
-    pub(crate) fn cast<U>(self) -> Frame<U> {
-        Frame {
-            header: self.header.cast(),
-            body: self.body
-        }
+    /// Introduce this frame to the right of a binary frame type.
+    pub(crate) fn right<U>(self) -> Frame<Either<U, T>> {
+        Frame { header: self.header.right(), body: self.body }
+    }
+
+    /// Introduce this frame to the left of a binary frame type.
+    pub(crate) fn left<U>(self) -> Frame<Either<T, U>> {
+        Frame { header: self.header.left(), body: self.body }
+    }
+}
+
+impl Frame<()> {
+    pub(crate) fn as_data(self) -> Frame<Data> {
+        Frame { header: self.header.as_data(), body: self.body }
+    }
+
+    pub(crate) fn as_window_update(self) -> Frame<WindowUpdate> {
+        Frame { header: self.header.as_window_update(), body: self.body }
+    }
+
+    pub(crate) fn as_ping(self) -> Frame<Ping> {
+        Frame { header: self.header.as_ping(), body: self.body }
     }
 }
 

--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -67,12 +67,12 @@ impl<T> Header<T> {
         }
     }
 
-    /// Introduce this header to the left of a binary header type.
+    /// Introduce this header to the right of a binary header type.
     pub(crate) fn right<U>(self) -> Header<Either<U, T>> {
         self.cast()
     }
 
-    /// Introduce this header to the right of a binary header type.
+    /// Introduce this header to the left of a binary header type.
     pub(crate) fn left<U>(self) -> Header<Either<T, U>> {
         self.cast()
     }
@@ -438,4 +438,3 @@ mod tests {
             .quickcheck(property as fn(Header<()>) -> bool)
     }
 }
-

--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -79,17 +79,17 @@ impl<T> Header<T> {
 }
 
 impl Header<()> {
-    pub(crate) fn as_data(self) -> Header<Data> {
+    pub(crate) fn into_data(self) -> Header<Data> {
         debug_assert_eq!(self.tag, Tag::Data);
         self.cast()
     }
 
-    pub(crate) fn as_window_update(self) -> Header<WindowUpdate> {
+    pub(crate) fn into_window_update(self) -> Header<WindowUpdate> {
         debug_assert_eq!(self.tag, Tag::WindowUpdate);
         self.cast()
     }
 
-    pub(crate) fn as_ping(self) -> Header<Ping> {
+    pub(crate) fn into_ping(self) -> Header<Ping> {
         debug_assert_eq!(self.tag, Tag::Ping);
         self.cast()
     }

--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -8,6 +8,7 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
+use futures::future::Either;
 use std::fmt;
 use thiserror::Error;
 
@@ -54,7 +55,8 @@ impl<T> Header<T> {
         self.length = Len(len)
     }
 
-    pub(crate) fn cast<U>(self) -> Header<U> {
+    /// Arbitrary type cast, use with caution.
+    fn cast<U>(self) -> Header<U> {
         Header {
             version: self.version,
             tag: self.tag,
@@ -63,6 +65,33 @@ impl<T> Header<T> {
             length: self.length,
             _marker: std::marker::PhantomData
         }
+    }
+
+    /// Introduce this header to the left of a binary header type.
+    pub(crate) fn right<U>(self) -> Header<Either<U, T>> {
+        self.cast()
+    }
+
+    /// Introduce this header to the right of a binary header type.
+    pub(crate) fn left<U>(self) -> Header<Either<T, U>> {
+        self.cast()
+    }
+}
+
+impl Header<()> {
+    pub(crate) fn as_data(self) -> Header<Data> {
+        debug_assert_eq!(self.tag, Tag::Data);
+        self.cast()
+    }
+
+    pub(crate) fn as_window_update(self) -> Header<WindowUpdate> {
+        debug_assert_eq!(self.tag, Tag::WindowUpdate);
+        self.cast()
+    }
+
+    pub(crate) fn as_ping(self) -> Header<Ping> {
+        debug_assert_eq!(self.tag, Tag::Ping);
+        self.cast()
     }
 }
 
@@ -195,12 +224,14 @@ pub trait HasSyn: private::Sealed {}
 impl HasSyn for Data {}
 impl HasSyn for WindowUpdate {}
 impl HasSyn for Ping {}
+impl<A: HasSyn, B: HasSyn> HasSyn for Either<A, B> {}
 
 /// Types which have an `ack` method.
 pub trait HasAck: private::Sealed {}
 impl HasAck for Data {}
 impl HasAck for WindowUpdate {}
 impl HasAck for Ping {}
+impl<A: HasAck, B: HasAck> HasAck for Either<A, B> {}
 
 /// Types which have a `fin` method.
 pub trait HasFin: private::Sealed {}
@@ -218,6 +249,7 @@ mod private {
     impl Sealed for super::Data {}
     impl Sealed for super::WindowUpdate {}
     impl Sealed for super::Ping {}
+    impl<A: Sealed, B: Sealed> Sealed for super::Either<A, B> {}
 }
 
 /// A tag is the runtime representation of a message type.
@@ -322,7 +354,7 @@ pub fn encode<T>(hdr: &Header<T>) -> [u8; HEADER_SIZE] {
 }
 
 /// Decode a [`Header`] value.
-pub fn decode<T>(buf: &[u8; HEADER_SIZE]) -> Result<Header<T>, HeaderDecodeError> {
+pub fn decode(buf: &[u8; HEADER_SIZE]) -> Result<Header<()>, HeaderDecodeError> {
     if buf[0] != 0 {
         return Err(HeaderDecodeError::Version(buf[0]))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,13 +74,15 @@ pub enum WindowUpdateMode {
 /// - max. number of streams = 8192
 /// - window update mode = on receive
 /// - read after close = true
+/// - lazy open = false
 #[derive(Debug, Clone)]
 pub struct Config {
     receive_window: u32,
     max_buffer_size: usize,
     max_num_streams: usize,
     window_update_mode: WindowUpdateMode,
-    read_after_close: bool
+    read_after_close: bool,
+    lazy_open: bool
 }
 
 impl Default for Config {
@@ -90,7 +92,8 @@ impl Default for Config {
             max_buffer_size: 1024 * 1024,
             max_num_streams: 8192,
             window_update_mode: WindowUpdateMode::OnReceive,
-            read_after_close: true
+            read_after_close: true,
+            lazy_open: false
         }
     }
 }
@@ -129,6 +132,22 @@ impl Config {
     /// the connection has been closed.
     pub fn set_read_after_close(&mut self, b: bool) -> &mut Self {
         self.read_after_close = b;
+        self
+    }
+
+    /// Enable or disable deferred sending of an initial control frame
+    /// when opening outbound streams.
+    ///
+    /// When enabled, opening a new outbound stream will not result in an
+    /// immediate send of a control frame, but the information will be put
+    /// into the first data frame that is being delivered to the remote.
+    ///
+    /// When disabled (the current default), opening a new outbound
+    /// stream will result in a window update being sent to the remote.
+    /// This allows opening a stream with a custom receive window size (cf.
+    /// `set_receive_window`) which the remote can immediately make use of.
+    pub fn set_lazy_open(&mut self, b: bool) -> &mut Self {
+        self.lazy_open = b;
         self
     }
 }


### PR DESCRIPTION
This PR changes two aspects related to newly opened inbound and outbound streams:

1. Up to now we never replied to opened inbound streams with an `ACK` flag, despite the fact that the spec clearly demands this behaviour. While we continue to ignore any `ACK` flags we receive, with this change we properly set an `ACK` flag if required.
2. The current behaviour is to always immediately send a `WindowUpdate` frame to the remote when opening an outbound stream. While we do not wait for an acknowledgement before we continue to send data over the stream, we could also hold off and set the initial `SYN` flag in the first data frame that is being sent over the new stream to the remote. The newly added option `lazy_open` enables this. This should eventually become the new default.

Additionally, this PR makes casting of header and frame types more principled. Instead of arbitrary casts only casts from `()` to `Data`, `WindowUpdate` and `Ping` are allowed. We also model a binary sum type and provide introductions from `T` to `Either<T, U>` and `T` to `Either<U, T>` but no projections. This allows a more type-safe `StreamCommand` whose `SendFrame` constructor only accepts `Frame<Either<Data, WindowUpdate>>` values which is what we expect coming from streams.