### PR TITLE
Remove `bytes` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
 futures = "0.3.1"
 log = "0.4.8"
 nohash-hasher = "0.2"
 parking_lot = "0.10"
 rand = "0.7.2"
+static_assertions = "1"
 thiserror = "1"
 
 [dev-dependencies]

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -8,45 +8,102 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use bytes::Bytes;
-use std::collections::VecDeque;
+use std::{collections::VecDeque, io};
 
-/// A sequence of [`Bytes`] values.
+/// A sequence of [`Chunk`] values.
 ///
-/// [`Chunks::len`] considers all [`Bytes`] elements and computes the total
+/// [`Chunks::len`] considers all [`Chunk`] elements and computes the total
 /// result, e.g. the length of all bytes by summing up the lengths of all
-/// [`Bytes`] elements.
+/// [`Chunk`] elements.
 #[derive(Debug)]
 pub(crate) struct Chunks {
-    seq: VecDeque<Bytes>
+    seq: VecDeque<Chunk>
 }
 
 impl Chunks {
+    /// A new empty chunk list.
     pub(crate) fn new() -> Self {
         Chunks { seq: VecDeque::new() }
     }
 
+    /// Does this chunk list contain any bytes?
     pub(crate) fn is_empty(&self) -> bool {
         self.seq.iter().all(|x| x.is_empty())
     }
 
+    /// The total length of bytes contained in all `Chunk`s.
     pub(crate) fn len(&self) -> Option<usize> {
         self.seq.iter().fold(Some(0), |total, x| {
             total.and_then(|n| n.checked_add(x.len()))
         })
     }
 
-    pub(crate) fn push(&mut self, x: Bytes) {
+    /// Add another chunk of bytes to the end.
+    pub(crate) fn push(&mut self, x: Vec<u8>) {
         if !x.is_empty() {
-            self.seq.push_back(x)
+            self.seq.push_back(Chunk { cursor: io::Cursor::new(x) })
         }
     }
 
-    pub(crate) fn pop(&mut self) -> Option<Bytes> {
+    /// Remove and return the first chunk.
+    pub(crate) fn pop(&mut self) -> Option<Chunk> {
         self.seq.pop_front()
     }
 
-    pub(crate) fn front_mut(&mut self) -> Option<&mut Bytes> {
+    /// Get a mutable reference to the first chunk.
+    pub(crate) fn front_mut(&mut self) -> Option<&mut Chunk> {
         self.seq.front_mut()
     }
 }
+
+/// A `Chunk` wraps a `std::io::Cursor<Vec<u8>>`.
+///
+/// It provides a byte-slice view and a way to advance the cursor so the
+/// vector can be consumed in steps.
+#[derive(Debug)]
+pub(crate) struct Chunk {
+    cursor: io::Cursor<Vec<u8>>
+}
+
+impl Chunk {
+    /// Is this chunk empty?
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The remaining number of bytes in this `Chunk`.
+    pub(crate) fn len(&self) -> usize {
+        self.cursor.get_ref().len() - self.offset()
+    }
+
+    /// The sum of bytes that the cursor has been `advance`d over.
+    pub(crate) fn offset(&self) -> usize {
+        self.cursor.position() as usize
+    }
+
+    /// Move the cursor position by `amount` bytes.
+    ///
+    /// The `AsRef<[u8]>` impl of `Chunk` gives a byte-slice from the
+    /// current position to the end.
+    pub(crate) fn advance(&mut self, amount: usize) {
+        assert!({ // the new position must not exceed the vector's length
+            let pos = self.offset().checked_add(amount);
+            let max = self.cursor.get_ref().len();
+            pos.is_some() && pos <= Some(max)
+        });
+
+        self.cursor.set_position(self.cursor.position() + amount as u64);
+    }
+
+    /// Cunsume self and return the inner vector.
+    pub(crate) fn into_vec(self) -> Vec<u8> {
+        self.cursor.into_inner()
+    }
+}
+
+impl AsRef<[u8]> for Chunk {
+    fn as_ref(&self) -> &[u8] {
+        &self.cursor.get_ref()[self.offset() ..]
+    }
+}
+

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -13,7 +13,7 @@ use std::{collections::VecDeque, io};
 /// A sequence of [`Chunk`] values.
 ///
 /// [`Chunks::len`] considers all [`Chunk`] elements and computes the total
-/// result, e.g. the length of all bytes by summing up the lengths of all
+/// result, i.e. the length of all bytes, by summing up the lengths of all
 /// [`Chunk`] elements.
 #[derive(Debug)]
 pub(crate) struct Chunks {
@@ -83,8 +83,8 @@ impl Chunk {
 
     /// Move the cursor position by `amount` bytes.
     ///
-    /// The `AsRef<[u8]>` impl of `Chunk` gives a byte-slice from the
-    /// current position to the end.
+    /// The `AsRef<[u8]>` impl of `Chunk` provides a byte-slice view
+    /// from the current position to the end.
     pub(crate) fn advance(&mut self, amount: usize) {
         assert!({ // the new position must not exceed the vector's length
             let pos = self.offset().checked_add(amount);
@@ -95,7 +95,7 @@ impl Chunk {
         self.cursor.set_position(self.cursor.position() + amount as u64);
     }
 
-    /// Cunsume self and return the inner vector.
+    /// Consume `self` and return the inner vector.
     pub(crate) fn into_vec(self) -> Vec<u8> {
         self.cursor.into_inner()
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -11,23 +11,23 @@
 pub mod header;
 mod io;
 
-use bytes::Bytes;
 use futures::future::Either;
 use header::{Header, StreamId, Data, WindowUpdate, GoAway, Ping};
 use std::{convert::TryInto, num::TryFromIntError};
 
-pub use io::{Io, FrameDecodeError};
+pub(crate) use io::Io;
+pub use io::FrameDecodeError;
 
 /// A Yamux message frame consisting of header and body.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Frame<T> {
     header: Header<T>,
-    body: Bytes
+    body: Vec<u8>
 }
 
 impl<T> Frame<T> {
     pub fn new(header: Header<T>) -> Self {
-        Frame { header, body: Bytes::new() }
+        Frame { header, body: Vec::new() }
     }
 
     pub fn header(&self) -> &Header<T> {
@@ -64,24 +64,24 @@ impl Frame<()> {
 }
 
 impl Frame<Data> {
-    pub fn data(id: StreamId, b: Bytes) -> Result<Self, TryFromIntError> {
+    pub fn data(id: StreamId, b: Vec<u8>) -> Result<Self, TryFromIntError> {
         Ok(Frame {
             header: Header::data(id, b.len().try_into()?),
             body: b
         })
     }
 
-    pub fn body(&self) -> &Bytes {
+    pub fn body(&self) -> &[u8] {
         &self.body
     }
 
     pub fn body_len(&self) -> u32 {
         // Safe cast since we construct `Frame::<Data>`s only with
-        // `Bytes` of length [0, u32::MAX] in `Frame::data` above.
+        // `Vec<u8>` of length [0, u32::MAX] in `Frame::data` above.
         self.body().len() as u32
     }
 
-    pub fn into_body(self) -> Bytes {
+    pub fn into_body(self) -> Vec<u8> {
         self.body
     }
 }
@@ -90,7 +90,7 @@ impl Frame<WindowUpdate> {
     pub fn window_update(id: StreamId, credit: u32) -> Self {
         Frame {
             header: Header::window_update(id, credit),
-            body: Bytes::new()
+            body: Vec::new()
         }
     }
 }
@@ -99,21 +99,21 @@ impl Frame<GoAway> {
     pub fn term() -> Self {
         Frame {
             header: Header::term(),
-            body: Bytes::new()
+            body: Vec::new()
         }
     }
 
     pub fn protocol_error() -> Self {
         Frame {
             header: Header::protocol_error(),
-            body: Bytes::new()
+            body: Vec::new()
         }
     }
 
     pub fn internal_error() -> Self {
         Frame {
             header: Header::internal_error(),
-            body: Bytes::new()
+            body: Vec::new()
         }
     }
 }

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -8,81 +8,59 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-use crate::u32_as_usize;
-use futures::{io::BufWriter, prelude::*, ready};
-use std::{io, pin::Pin, task::{Context, Poll}};
+use crate::connection::Id;
+use futures::{prelude::*, ready};
+use std::{fmt, io, pin::Pin, task::{Context, Poll}};
 use super::{Frame, header::{self, HeaderDecodeError}};
 use thiserror::Error;
 
-/// When growing buffers we allocate units of `BLOCKSIZE`.
-/// We also use this value to buffer write operations.
-const BLOCKSIZE: usize = 8 * 1024;
-
 /// A [`Stream`] and writer of [`Frame`] values.
 #[derive(Debug)]
-pub struct Io<T> {
-    io: BufWriter<T>,
-    buffer: buf::Buffer,
-    header: Option<header::Header<()>>,
+pub(crate) struct Io<T> {
+    id: Id,
+    io: T,
+    state: ReadState,
     max_body_len: usize
 }
 
 impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
-    pub fn new(io: T, max_frame_body_len: usize) -> Self {
+    pub(crate) fn new(id: Id, io: T, max_frame_body_len: usize) -> Self {
         Io {
-            io: BufWriter::with_capacity(BLOCKSIZE, io),
-            buffer: buf::Buffer::new(),
-            header: None,
+            id,
+            io,
+            state: ReadState::Init,
             max_body_len: max_frame_body_len
         }
     }
 
-    pub async fn send<A>(&mut self, frame: &Frame<A>) -> io::Result<()> {
+    pub(crate) async fn send<A>(&mut self, frame: &Frame<A>) -> io::Result<()> {
         let header = header::encode(&frame.header);
         self.io.write_all(&header).await?;
         self.io.write_all(&frame.body).await
     }
 
-    pub async fn flush(&mut self) -> io::Result<()> {
+    pub(crate) async fn flush(&mut self) -> io::Result<()> {
         self.io.flush().await
     }
 
-    pub async fn close(&mut self) -> io::Result<()> {
+    pub(crate) async fn close(&mut self) -> io::Result<()> {
         self.io.close().await
     }
+}
 
-    /// Try to decode a [`Frame`] from the internal buffer.
-    ///
-    /// Returns `Ok(None)` if more data is needed, otherwise some
-    /// frame or a decoding error.
-    fn decode(&mut self) -> Result<Option<Frame<()>>, FrameDecodeError> {
-        if self.header.is_none() {
-            if self.buffer.len() < header::HEADER_SIZE {
-                return Ok(None)
-            }
-            let mut b = [0u8; header::HEADER_SIZE];
-            b.copy_from_slice(self.buffer.split_to(header::HEADER_SIZE).as_ref());
-            let header = header::decode(&b)?;
-            if header.tag() != header::Tag::Data {
-                return Ok(Some(Frame::new(header)))
-            }
-            if u32_as_usize(header.len().val()) > self.max_body_len {
-                return Err(FrameDecodeError::FrameTooLarge(u32_as_usize(header.len().val())))
-            }
-            self.buffer.reserve(u32_as_usize(header.len().val()));
-            self.header = Some(header)
-        }
-
-        if let Some(header) = self.header.take() {
-            let n = u32_as_usize(header.len().val());
-            if n <= self.buffer.len() {
-                let bytes = self.buffer.split_to(n).into_bytes();
-                return Ok(Some(Frame { header, body: bytes.freeze() }))
-            }
-            self.header = Some(header)
-        }
-
-        Ok(None)
+enum ReadState {
+    /// Initial reading state.
+    Init,
+    /// Reading the frame header.
+    Header {
+        offset: usize,
+        buffer: [u8; header::HEADER_SIZE]
+    },
+    /// Reading the frame body.
+    Body {
+        header: header::Header<()>,
+        offset: usize,
+        buffer: Vec<u8>
     }
 }
 
@@ -90,109 +68,97 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Stream for Io<T> {
     type Item = Result<Frame<()>, FrameDecodeError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let mut this = &mut *self;
         loop {
-            match self.decode() {
-                Ok(Some(f)) => return Poll::Ready(Some(Ok(f))),
-                Ok(None) => {
-                    if self.buffer.remaining_mut() < BLOCKSIZE {
-                        self.buffer.reserve(BLOCKSIZE)
+            log::trace!("{}: read: {:?}", this.id, this.state);
+            match this.state {
+                ReadState::Init => {
+                    this.state = ReadState::Header {
+                        offset: 0,
+                        buffer: [0; header::HEADER_SIZE]
+                    };
+                }
+                ReadState::Header { ref mut offset, ref mut buffer } => {
+                    if *offset == header::HEADER_SIZE {
+                        let header =
+                            match header::decode(&buffer) {
+                                Ok(hd) => hd,
+                                Err(e) => return Poll::Ready(Some(Err(e.into())))
+                            };
+
+                        log::trace!("{}: read: {}", this.id, header);
+
+                        if header.tag() != header::Tag::Data {
+                            this.state = ReadState::Init;
+                            return Poll::Ready(Some(Ok(Frame::new(header))))
+                        }
+
+                        let body_len = header.len().val() as usize;
+
+                        if body_len > this.max_body_len {
+                            return Poll::Ready(Some(Err(FrameDecodeError::FrameTooLarge(body_len))))
+                        }
+
+                        this.state = ReadState::Body {
+                            header,
+                            offset: 0,
+                            buffer: vec![0; body_len]
+                        };
+
+                        continue
                     }
-                    let this = &mut *self;
-                    let write_buffer = this.buffer.bytes_mut();
-                    match ready!(Pin::new(this.io.get_mut()).poll_read(cx, write_buffer)?) {
+
+                    let buf = &mut buffer[*offset .. header::HEADER_SIZE];
+                    match ready!(Pin::new(&mut this.io).poll_read(cx, buf))? {
                         0 => {
-                            if this.header.is_none() && this.buffer.is_empty() {
+                            if *offset == 0 {
                                 return Poll::Ready(None)
                             }
                             let e = FrameDecodeError::Io(io::ErrorKind::UnexpectedEof.into());
                             return Poll::Ready(Some(Err(e)))
                         }
-                        n => this.buffer.advance_mut(n)
+                        n => *offset += n
                     }
                 }
-                Err(e) => return Poll::Ready(Some(Err(e)))
+                ReadState::Body { ref header, ref mut offset, ref mut buffer } => {
+                    let body_len = header.len().val() as usize;
+
+                    if *offset == body_len {
+                        let h = header.clone();
+                        let v = std::mem::take(buffer);
+                        this.state = ReadState::Init;
+                        return Poll::Ready(Some(Ok(Frame { header: h, body: v })))
+                    }
+
+                    let buf = &mut buffer[*offset .. body_len];
+                    match ready!(Pin::new(&mut this.io).poll_read(cx, buf))? {
+                        0 => {
+                            let e = FrameDecodeError::Io(io::ErrorKind::UnexpectedEof.into());
+                            return Poll::Ready(Some(Err(e)))
+                        }
+                        n => *offset += n
+                    }
+                }
             }
         }
     }
 }
 
-mod buf {
-    use bytes::{BufMut, BytesMut};
-    use std::{mem::{self, MaybeUninit}, ptr};
-
-    /// Wrapper around `BytesMut` with a safe API.
-    #[derive(Debug)]
-    pub struct Buffer(BytesMut);
-
-    impl Buffer {
-        /// Create a fresh empty buffer.
-        pub fn new() -> Self {
-            Buffer(BytesMut::new())
-        }
-
-        /// Is this buffer empty?
-        pub fn is_empty(&self) -> bool {
-            self.0.is_empty()
-        }
-
-        /// Buffer length in bytes.
-        pub fn len(&self) -> usize {
-            self.0.len()
-        }
-
-        /// The remaining write capacity of this buffer.
-        pub fn remaining_mut(&self) -> usize {
-            self.0.capacity() - self.0.len()
-        }
-
-        /// Set `self` to `self[n ..]` and return `self[.. n]`.
-        pub fn split_to(&mut self, n: usize) -> Self {
-            Buffer(self.0.split_to(n))
-        }
-
-        /// Extract the underlying storage bytes.
-        pub fn into_bytes(self) -> BytesMut {
-            self.0
-        }
-
-        /// Reserve and initialise more capacity.
-        pub fn reserve(&mut self, additional: usize) {
-            let old = self.0.capacity();
-            self.0.reserve(additional);
-            let new = self.0.capacity();
-            if new > old {
-                let b = self.0.bytes_mut();
-                unsafe {
-                    // Safe because we never read from `b` and stay within
-                    // the boundaries of `b` when writing.
-                    ptr::write_bytes(b.as_mut_ptr(), 0, b.len())
-                }
+impl fmt::Debug for ReadState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ReadState::Init => {
+                f.write_str("(ReadState::Init)")
             }
-        }
-
-        /// Get a mutable handle to the remaining write capacity.
-        pub fn bytes_mut(&mut self) -> &mut [u8] {
-            let b = self.0.bytes_mut();
-            unsafe {
-                // Safe because `reserve` always initialises memory.
-                mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b)
+            ReadState::Header { offset, .. } => {
+                write!(f, "(ReadState::Header {})", offset)
             }
-        }
-
-        /// Increment the buffer length by `n` bytes.
-        pub fn advance_mut(&mut self, n: usize) {
-            assert!(n <= self.remaining_mut(), "{} > {}", n, self.remaining_mut());
-            unsafe {
-                // Safe because we have established that `n` does not exceed
-                // the remaining capacity.
-                self.0.advance_mut(n)
+            ReadState::Body { header, offset, buffer } => {
+                write!(f, "(ReadState::Body (header {}) (offset {}) (buffer-len {}))",
+                    header,
+                    offset,
+                    buffer.len())
             }
-        }
-    }
-
-    impl AsRef<[u8]> for Buffer {
-        fn as_ref(&self) -> &[u8] {
-            self.0.as_ref()
         }
     }
 }
@@ -216,7 +182,6 @@ pub enum FrameDecodeError {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
     use quickcheck::{Arbitrary, Gen, QuickCheck};
     use rand::RngCore;
     use super::*;
@@ -227,11 +192,11 @@ mod tests {
             let body =
                 if header.tag() == header::Tag::Data {
                     header.set_len(header.len().val() % 4096);
-                    let mut b = vec![0; u32_as_usize(header.len().val())];
+                    let mut b = vec![0; header.len().val() as usize];
                     rand::thread_rng().fill_bytes(&mut b);
-                    Bytes::from(b)
+                    b
                 } else {
-                    Bytes::new()
+                    Vec::new()
                 };
             Frame { header, body }
         }
@@ -241,15 +206,15 @@ mod tests {
     fn encode_decode_identity() {
         fn property(f: Frame<()>) -> bool {
             async_std::task::block_on(async move {
-                let buf = Vec::with_capacity(header::HEADER_SIZE + f.body.len());
-                let mut io = Io::new(futures::io::Cursor::new(buf), f.body.len());
+                let id = crate::connection::Id::random();
+                let mut io = Io::new(id, futures::io::Cursor::new(Vec::new()), f.body.len());
                 if io.send(&f).await.is_err() {
                     return false
                 }
                 if io.flush().await.is_err() {
                     return false
                 }
-                io.io.get_mut().set_position(0);
+                io.io.set_position(0);
                 if let Ok(Some(x)) = io.try_next().await {
                     x == f
                 } else {

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -48,6 +48,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Io<T> {
     }
 }
 
+/// The stages of reading a new `Frame`.
 enum ReadState {
     /// Initial reading state.
     Init,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@
 //!
 //! [1]: https://github.com/hashicorp/yamux/blob/master/spec.md
 
+#![forbid(unsafe_code)]
+
 mod chunks;
 mod error;
 mod frame;
@@ -153,8 +155,13 @@ impl Config {
     }
 }
 
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-const fn u32_as_usize(a: u32) -> usize {
-    a as usize
+// Check that we can safely cast a `usize` to a `u64`.
+static_assertions::const_assert! {
+    std::mem::size_of::<usize>() <= std::mem::size_of::<u64>()
+}
+
+// Check that we can safely cast a `u32` to a `usize`.
+static_assertions::const_assert! {
+    std::mem::size_of::<u32>() <= std::mem::size_of::<usize>()
 }
 


### PR DESCRIPTION
The motivation for this change is the worry, that streams which do not consume their buffers in a timely manner prevent `BytesMut` from reusing their storage space, instead forcing it to allocate more memory.

This PR removes `bytes` completely and instead uses `Vec<u8>`s. The reclamation of storage is left to the allocator. As a side effect, all instances of `unsafe` are removed, so if merged, #66 can be considered done.

While at it we also remove the `BufWriter` from `Io`. Client code often already uses buffers and always adding another buffer layer seems misguided. If desired clients may always provide `Connection::new` with a `BufWriter` type.