### PR TITLE
Add check for BrokenPipe io error

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -590,6 +590,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 log::debug!("{}: socket eof", self.id);
                 Err(ConnectionError::Closed)
             }
+            Err(e) if e.io_kind() == Some(std::io::ErrorKind::BrokenPipe) => {
+                log::debug!("{}: broken pipe", self.id);
+                Err(ConnectionError::Closed)
+            }
             Err(e) if e.io_kind() == Some(std::io::ErrorKind::ConnectionReset) => {
                 log::debug!("{}: connection reset", self.id);
                 Err(ConnectionError::Closed)


### PR DESCRIPTION
If there is a broken pipe from the socket, the connection should close.