### PR TITLE
Fix race on final FIN or RST frames.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ static_assertions = "1"
 
 [dev-dependencies]
 anyhow = "1"
-async-std = "1"
+async-std = "~1.5"
 criterion = "0.3"
 futures = "0.3.4"
 quickcheck = "0.9"


### PR DESCRIPTION
When a stream is dropped after sending some data, the corresponding `SendFrame` commands may still be in the
queue when stream garbage collection kicks in. Stream garbage collection conditionally sends final FIN or RST frames, but it does so directly on the socket, thus these frames may be sent (and hence received) before other frames that may have been sent before the stream was dropped, giving the remote a premature EOF.

The proposal here to address this problem is to send the final FIN or RST frames through the `stream_sender`, so they are guaranteed to be sent last, since the stream has already been dropped. As a side-effect, these frames being sent also turn
up in the trace logs, which was not the case before and made it a bit more difficult to diagnose.