### PR TITLE
Fix read-after-close?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ static_assertions = "1"
 
 [dev-dependencies]
 anyhow = "1"
-async-std = "1"
+async-std = "~1.5"
 criterion = "0.3"
 futures = "0.3.4"
 quickcheck = "0.9"


### PR DESCRIPTION
Currently the `Stream` and `AsyncRead` impls for streams check the condition for read-after-close based on whether
the stream command sender is closed, but that never seems to be the case, unless the receiver is dropped which only happens when the connection closes. I'm not sure whether this is intentional. Should read-after-close on a substream always work as long as the connection is not closed?

As a preliminary suggestion, I've changed the condition to check the substream state instead of whether the sender is closed.