### PR TITLE
Reset dropped stream if window == 0.

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -26,11 +26,6 @@ impl Chunks {
         Chunks { seq: VecDeque::new() }
     }
 
-    /// Does this chunk list contain any bytes?
-    pub(crate) fn is_empty(&self) -> bool {
-        self.seq.iter().all(|x| x.is_empty())
-    }
-
     /// The total length of bytes contained in all `Chunk`s.
     pub(crate) fn len(&self) -> Option<usize> {
         self.seq.iter().fold(Some(0), |total, x| {


### PR DESCRIPTION
If `WindowUpdateMode` is `OnRead` and a stream is in state `SendClosed` when being dropped, we consider its buffer to determine if the remote may be blocked and needs to receive a reset frame. This is a bit odd as we could and should rather look at the stream's actual window size. If it is 0 we know that the remote may be blocked and since the stream is dropped no further window updates are forthcoming from our side, hence a RST frame should be sent right away. If it is > 0 the remote either has credit left or if it has not then the socket buffer must contain more data and we will answer with a RST for any unknown stream, so no action is necessary.

So why are we not looking at `window`? The reason is that we currently update the window before the window update is enqueued and if `poll_read` is not called again it may never be. To fix this we must ensure that the value of window is only updated after the window update has been enqueued properly so we know it will eventually be sent to the remote.
Once we have ensured that it is done correctly we may safely look at `window` in `garbage_collect` and proceed as outlined above.