### PR TITLE
Send window update for initial data.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -198,7 +198,7 @@ enum Action {
     /// Nothing to be done.
     None,
     /// A new stream has been opened by the remote.
-    New(Stream),
+    New(Stream, Option<Frame<WindowUpdate>>),
     /// A window update should be sent to the remote.
     Update(Frame<WindowUpdate>),
     /// A ping should be answered.
@@ -573,8 +573,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 };
                 match action {
                     Action::None => {}
-                    Action::New(stream) => {
+                    Action::New(stream, update) => {
                         log::trace!("{}: new inbound {} of {}", self.id, stream, self);
+                        if let Some(f) = update {
+                            log::trace!("{}/{}: sending update", self.id, f.header().stream_id());
+                            self.socket.get_mut().send(&f).await.or(Err(ConnectionError::Closed))?
+                        }
                         return Ok(Some(stream))
                     }
                     Action::Update(f) => {
@@ -655,6 +659,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 stream.set_flag(stream::Flag::Ack);
                 stream
             };
+            let window_update;
             {
                 let mut shared = stream.shared();
                 if is_finish {
@@ -662,9 +667,19 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 }
                 shared.window = shared.window.saturating_sub(frame.body_len());
                 shared.buffer.push(frame.into_body());
+                if !is_finish
+                    && shared.window == 0
+                    && self.config.window_update_mode == WindowUpdateMode::OnReceive
+                {
+                    shared.window = self.config.receive_window;
+                    let frame = Frame::window_update(stream_id, self.config.receive_window);
+                    window_update = Some(frame)
+                } else {
+                    window_update = None
+                }
             }
             self.streams.insert(stream_id, stream.clone());
-            return Action::New(stream)
+            return Action::New(stream, window_update)
         }
 
         if let Some(stream) = self.streams.get_mut(&stream_id) {
@@ -750,7 +765,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 stream.shared().update_state(self.id, stream_id, State::RecvClosed);
             }
             self.streams.insert(stream_id, stream.clone());
-            return Action::New(stream)
+            return Action::New(stream, None)
         }
 
         if let Some(stream) = self.streams.get_mut(&stream_id) {


### PR DESCRIPTION
PR #73 introduced a lazy open option to defer sending the initial frame when actual data is sent. If enabled and the initial data size equals DEFAULT_CREDIT (i.e. 256 KiB), it is necessary to immediately send a window update back when accepting such a stream, but only if window update mode is `OnReceive`, otherwise the update will be sent when the stream data is consumed.

With more options there are more ways how things can influence each other, so I have changed some tests to work with randomly generated configurations to test more combinations.