### PR TITLE
If `lazy_open` use the default receive window.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -472,7 +472,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 let stream = {
                     let config = self.config.clone();
                     let sender = self.stream_sender.clone();
-                    let window = self.config.receive_window;
+                    let window =
+                        if self.config.lazy_open {
+                            DEFAULT_CREDIT
+                        } else {
+                            self.config.receive_window
+                        };
                     let mut stream = Stream::new(id, self.id, config, window, DEFAULT_CREDIT, sender);
                     if self.config.lazy_open {
                         stream.set_flag(stream::Flag::Syn)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -223,6 +223,7 @@ impl Arbitrary for TestConfig {
         });
         c.set_lazy_open(g.gen());
         c.set_read_after_close(g.gen());
+        c.set_receive_window(g.gen_range(256 * 1024, 1024 * 1024));
         TestConfig(c)
     }
 }


### PR DESCRIPTION
The current implementation always uses the configured receive window for the remote. However, when not sending the initial window update, this means that the remote stops sending before having used up its credit which it assumes matches the default receive window as it has not received an initial window update. Therefore, if `lazy_open` is true, the default receive window must be used initially.