### PR TITLE
src/tests: Write and read concurrently

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -47,7 +47,7 @@ fn prop_config_send_recv_single() {
             TestResult::from_bool(result.len() == num_requests && result.into_iter().eq(iter))
         })
     }
-    QuickCheck::new().quickcheck(prop as fn(_, _, _) -> _)
+    QuickCheck::new().tests(10).quickcheck(prop as fn(_, _, _) -> _)
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn prop_config_send_recv_multi() {
             TestResult::from_bool(result.len() == num_requests && result.into_iter().eq(iter))
         })
     }
-    QuickCheck::new().quickcheck(prop as fn(_, _, _) -> _)
+    QuickCheck::new().tests(10).quickcheck(prop as fn(_, _, _) -> _)
 }
 
 #[test]


### PR DESCRIPTION
* src/tests: Write and read concurrently

   Most of the tests in `src/tests.rs` have the structure of a client
   sending data to a server which in turn echoes the data back to the
   client which reads it in full and compares it to what it initially sent.
   
   Some of the tests use randomly generated configurations where the
   `WindowUpdateMode` can be either `OnRead` or `OnReceive`. When using
   `WindowUpdateMode::OnRead` the client can not first send a whole message to
   the server and only then receive the whole message from the server. Say that
   a single message exceeds the window between server and client. In such case
   the server would eventually exhaust its window to the client, thus not being
   able to forward bytes to the client, thus not accepting new bytes from the
   client, thus the client would be blocked on sending and thus the whole test
   would deadlock.
   
   With this commit the client writes and reads concurrently and thus does
   not run into a deadlock when executing with `WindowUpdateMode::OnRead`.

* src/tests: Restrict number of quickcheck runs

   With quickcheck iterations potentially taking long, restrict number of
   iterations per test to 10.