### PR TITLE
benches: Benchmark with constrained connections 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3.4"
 quickcheck = "0.9"
 tokio = { version = "0.2", features = ["tcp", "rt-threaded", "macros"] }
 tokio-util = { version = "0.3", features = ["compat"] }
+constrained-connection = "0.1"
 
 [[bench]]
 name = "concurrent"
 harness = false
-

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -82,6 +82,7 @@ async fn oneway(
                 let mut n = 0;
                 let mut b = vec![0; msg_len];
 
+                // Receive `nmessages` messages.
                 for _ in 0 .. nmessages {
                     stream.read_exact(&mut b[..]).await.unwrap();
                     n += b.len()
@@ -104,10 +105,11 @@ async fn oneway(
         task::spawn(async move {
             let mut stream = ctrl.open_stream().await.unwrap();
 
-            // Send and receive `nmessages` messages.
+            // Send `nmessages` messages.
             for _ in 0 .. nmessages {
                 stream.write_all(data.as_ref()).await.unwrap();
             }
+
             stream.close().await.unwrap();
             Ok::<(), yamux::ConnectionError>(())
         });

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -10,21 +10,13 @@
 
 use criterion::{BenchmarkId, criterion_group, criterion_main, Criterion, Throughput};
 use futures::{channel::mpsc, future, prelude::*, ready, io::AsyncReadExt};
-use std::{fmt, io, pin::Pin, sync::Arc, task::{Context, Poll}};
+use std::{fmt, io, pin::Pin, sync::Arc, task::{Context, Poll}, time::Duration};
 use tokio::{runtime::Runtime, task};
 use yamux::{Config, Connection, Mode};
+use constrained_connection::{Endpoint, new_unconstrained_connection, samples};
 
 criterion_group!(benches, concurrent);
 criterion_main!(benches);
-
-#[derive(Copy, Clone)]
-struct Params { streams: usize, messages: usize }
-
-impl fmt::Display for Params {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(streams {}, messages {})", self.streams, self.messages)
-    }
-}
 
 #[derive(Debug, Clone)]
 struct Bytes(Arc<Vec<u8>>);
@@ -37,134 +29,97 @@ impl AsRef<[u8]> for Bytes {
 
 fn concurrent(c: &mut Criterion) {
     let data = Bytes(Arc::new(vec![0x42; 4096]));
+    let networks = vec![
+        ("mobile", (|| samples::mobile_hsdpa().2) as fn() -> (_, _)),
+        ("adsl2+", (|| samples::residential_adsl2().2) as fn() -> (_, _)),
+        ("gbit-lan", (|| samples::gbit_lan().2) as fn() -> (_, _)),
+        ("unconstrained", new_unconstrained_connection as fn() -> (_, _)),
+    ];
 
     let mut group = c.benchmark_group("concurrent");
+    group.sample_size(10);
 
-    for nstreams in [1, 10, 100].iter() {
-        for nmessages in [1, 10, 100].iter() {
-            let params = Params { streams: *nstreams, messages: *nmessages };
-            let data = data.clone();
-            let mut rt = Runtime::new().unwrap();
-            group.throughput(Throughput::Bytes((nstreams * nmessages * data.0.len()) as u64));
-            group.bench_with_input(
-                BenchmarkId::from_parameter(params),
-                &params,
-                |b, &Params { streams, messages }| b.iter(||
-                    rt.block_on(roundtrip(streams, messages, data.clone()))
-                ),
-            );
+    for (network_name, new_connection) in networks.into_iter() {
+        for nstreams in [1, 10, 100].iter() {
+            for nmessages in [1, 10, 100].iter() {
+                let data = data.clone();
+                let mut rt = Runtime::new().unwrap();
+
+                group.throughput(Throughput::Bytes((nstreams * nmessages * data.0.len()) as u64));
+                group.bench_function(
+                    BenchmarkId::from_parameter(
+                        format!("{}/#streams{}/#messages{}", network_name, nstreams, nmessages),
+                    ),
+                    |b| b.iter(|| {
+                        let (server, client) = new_connection();
+                        rt.block_on(oneway(*nstreams, *nmessages, data.clone(), server, client))
+                    }),
+                );
+            }
         }
     }
 
     group.finish();
 }
 
-async fn roundtrip(nstreams: usize, nmessages: usize, data: Bytes) {
+fn config() -> Config {
+    let mut c = Config::default();
+    c.set_window_update_mode(yamux::WindowUpdateMode::OnRead);
+    c
+}
+
+async fn oneway(
+    nstreams: usize,
+    nmessages: usize,
+    data: Bytes,
+    server: Endpoint,
+    client: Endpoint,
+) {
     let msg_len = data.0.len();
-    let (server, client) = Endpoint::new();
-    let server = server.into_async_read();
-    let client = client.into_async_read();
+    let (tx, rx) = mpsc::unbounded();
 
     let server = async move {
-        yamux::into_stream(Connection::new(server, Config::default(), Mode::Server))
-            .try_for_each_concurrent(None, |mut stream| async move {
-                {
-                    let (mut r, mut w) = futures::io::AsyncReadExt::split(&mut stream);
-                    futures::io::copy(&mut r, &mut w).await?;
-                }
-                stream.close().await?;
-                Ok(())
-            })
-            .await
-            .expect("server works")
-    };
+        let mut connection = Connection::new(server, config(), Mode::Server);
 
+        while let Some(mut stream) = connection.next_stream().await.unwrap() {
+            let tx = tx.clone();
+
+            task::spawn(async move {
+                let mut n = 0;
+                let mut b = vec![0; msg_len];
+
+                for _ in 0 .. nmessages {
+                    stream.read_exact(&mut b[..]).await.unwrap();
+                    n += b.len()
+                }
+
+                tx.unbounded_send(n).expect("unbounded_send");
+                stream.close().await.unwrap();
+            });
+        }
+    };
     task::spawn(server);
 
-    let (tx, rx) = mpsc::unbounded();
-    let conn = Connection::new(client, Config::default(), Mode::Client);
+    let conn = Connection::new(client, config(), Mode::Client);
     let mut ctrl = conn.control();
-    task::spawn(yamux::into_stream(conn).for_each(|_| future::ready(())));
+    task::spawn(yamux::into_stream(conn).for_each(|r| {r.unwrap(); future::ready(())} ));
 
     for _ in 0 .. nstreams {
         let data = data.clone();
-        let tx = tx.clone();
         let mut ctrl = ctrl.clone();
         task::spawn(async move {
-            let stream = ctrl.open_stream().await?;
-            let (mut reader, mut writer) = AsyncReadExt::split(stream);
+            let mut stream = ctrl.open_stream().await.unwrap();
+
             // Send and receive `nmessages` messages.
-            let mut n = 0;
-            let mut b = vec![0; data.0.len()];
             for _ in 0 .. nmessages {
-                futures::future::join(
-                    writer.write_all(data.as_ref()).map(|r| r.unwrap()),
-                    reader.read_exact(&mut b[..]).map(|r| r.unwrap()),
-                ).await;
-                n += b.len()
+                stream.write_all(data.as_ref()).await.unwrap();
             }
-            let mut stream = reader.reunite(writer).unwrap();
-            stream.close().await?;
-            tx.unbounded_send(n).expect("unbounded_send");
+            stream.close().await.unwrap();
             Ok::<(), yamux::ConnectionError>(())
         });
     }
 
     let n = rx.take(nstreams).fold(0, |acc, n| future::ready(acc + n)).await;
     assert_eq!(n, nstreams * nmessages * msg_len);
-    ctrl.close().await.expect("close")
-}
-
-#[derive(Debug)]
-struct Endpoint {
-    incoming: mpsc::UnboundedReceiver<Vec<u8>>,
-    outgoing: mpsc::UnboundedSender<Vec<u8>>
-}
-
-impl Endpoint {
-    fn new() -> (Self, Self) {
-        let (tx_a, rx_a) = mpsc::unbounded();
-        let (tx_b, rx_b) = mpsc::unbounded();
-
-        let a = Endpoint { incoming: rx_a, outgoing: tx_b };
-        let b = Endpoint { incoming: rx_b, outgoing: tx_a };
-
-        (a, b)
-    }
-}
-
-impl Stream for Endpoint {
-    type Item = Result<Vec<u8>, io::Error>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        if let Some(b) = ready!(Pin::new(&mut self.incoming).poll_next(cx)) {
-            return Poll::Ready(Some(Ok(b)))
-        }
-        Poll::Pending
-    }
-}
-
-impl AsyncWrite for Endpoint {
-    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<io::Result<usize>> {
-        if ready!(Pin::new(&mut self.outgoing).poll_ready(cx)).is_err() {
-            return Poll::Ready(Err(io::ErrorKind::ConnectionAborted.into()))
-        }
-        let n = buf.len();
-        if Pin::new(&mut self.outgoing).start_send(Vec::from(buf)).is_err() {
-            return Poll::Ready(Err(io::ErrorKind::ConnectionAborted.into()))
-        }
-        Poll::Ready(Ok(n))
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.outgoing)
-            .poll_flush(cx)
-            .map_err(|_| io::ErrorKind::ConnectionAborted.into())
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.outgoing)
-            .poll_close(cx)
-            .map_err(|_| io::ErrorKind::ConnectionAborted.into())
-    }
+    ctrl.close().await.expect("close");
 }

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -62,12 +62,6 @@ fn concurrent(c: &mut Criterion) {
     group.finish();
 }
 
-fn config() -> Config {
-    let mut c = Config::default();
-    c.set_window_update_mode(yamux::WindowUpdateMode::OnRead);
-    c
-}
-
 async fn oneway(
     nstreams: usize,
     nmessages: usize,
@@ -79,7 +73,7 @@ async fn oneway(
     let (tx, rx) = mpsc::unbounded();
 
     let server = async move {
-        let mut connection = Connection::new(server, config(), Mode::Server);
+        let mut connection = Connection::new(server, Config::default(), Mode::Server);
 
         while let Some(mut stream) = connection.next_stream().await.unwrap() {
             let tx = tx.clone();
@@ -100,7 +94,7 @@ async fn oneway(
     };
     task::spawn(server);
 
-    let conn = Connection::new(client, config(), Mode::Client);
+    let conn = Connection::new(client, Config::default(), Mode::Client);
     let mut ctrl = conn.control();
     task::spawn(yamux::into_stream(conn).for_each(|r| {r.unwrap(); future::ready(())} ));
 

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -8,12 +8,12 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
+use constrained_connection::{Endpoint, new_unconstrained_connection, samples};
 use criterion::{BenchmarkId, criterion_group, criterion_main, Criterion, Throughput};
-use futures::{channel::mpsc, future, prelude::*, ready, io::AsyncReadExt};
-use std::{fmt, io, pin::Pin, sync::Arc, task::{Context, Poll}, time::Duration};
+use futures::{channel::mpsc, future, prelude::*, io::AsyncReadExt};
+use std::sync::Arc;
 use tokio::{runtime::Runtime, task};
 use yamux::{Config, Connection, Mode};
-use constrained_connection::{Endpoint, new_unconstrained_connection, samples};
 
 criterion_group!(benches, concurrent);
 criterion_main!(benches);


### PR DESCRIPTION
Previously the benchmarks would use an unbounded channel to simulate a
network connection. While this is helpful to measure the CPU impact of
Yamux specific changes, it is difficult to estimate how changes might
effect network throughput in different environments.

The crate [`constrained-connection`](https://github.com/mxinden/constrained-connection) can help simulate different
environments (DSL, HSDPA, GBit LAN, ...) by providing a channel
enforcing a specified bandwidth and delay. That said, it does not
simulate the OS network stack, routers, buffers, packet loss, ... Thus
as one would expect this can be used to detect trends, but not to e.g.
determine bandwidth expectations.

This commit makes the benchmarks run on top of a subset of the
connection types provided by [`constrained-connection`](https://github.com/mxinden/constrained-connection). In addition it
retains the simulation on top of an unconstrained connection.

When simulating with low bandwidth-delay-product connections, yamux can
deadlock in the roundtrip scenario. Imagine a client sending a large
payload exceeding the bandwidth-delay-product of the connection to a
server. The server will try to echo the payload back to the client. Once
both client and server exhausted the buffer provided through the
bandwidth-delay-product of the connection, neither will be able to make
progress as the other won't read from the connection. This commit
rewrites the benchmarks, only having the client send to the server, but
not the server echoing back to the client.

---

I hope for these benchmarks to be helpful when measuring the impact of https://github.com/libp2p/rust-libp2p/issues/1849 and https://github.com/paritytech/yamux/issues/100.

As an example below you can find the `critcmp` output of a run with `WindowUpdateMode::OnReceive` and `WindowUpdateMode::OnRead`. While the comparison of the two modes does not show a lot of difference, the throughput measurements on single / multi streams do.

You can find the bandwidth and the delay for each connection type (mobile, adsl2+, ...) [here](https://github.com/mxinden/constrained-connection/blob/master/src/lib.rs#L266).

```
$ critcmp on-read on-receive

group                                                on-read                                on-receive
-----                                                -------                                ----------
concurrent/adsl2+/#streams1/#messages1               1.00     25.4±0.08ms   157.3 KB/sec    1.01     25.6±0.07ms   156.1 KB/sec
concurrent/adsl2+/#streams1/#messages10              1.00     25.5±0.07ms  1566.0 KB/sec    1.00     25.6±0.15ms  1561.5 KB/sec
concurrent/adsl2+/#streams1/#messages100             1.00    227.7±0.15ms  1756.6 KB/sec    1.01    228.9±0.86ms  1747.1 KB/sec
concurrent/adsl2+/#streams10/#messages1              1.00     25.6±0.09ms  1560.9 KB/sec    1.01     25.9±0.06ms  1544.2 KB/sec
concurrent/adsl2+/#streams10/#messages10             1.00    177.1±0.16ms     2.2 MB/sec    1.01    178.4±0.30ms     2.2 MB/sec
concurrent/adsl2+/#streams10/#messages100            1.00   1671.1±7.84ms     2.3 MB/sec    1.00   1676.6±4.08ms     2.3 MB/sec
concurrent/adsl2+/#streams100/#messages1             1.00    177.5±0.26ms     2.2 MB/sec    1.00    177.9±0.50ms     2.2 MB/sec
concurrent/adsl2+/#streams100/#messages10            1.00   1668.3±0.49ms     2.3 MB/sec    1.00   1669.5±0.89ms     2.3 MB/sec
concurrent/adsl2+/#streams100/#messages100           1.00      16.6±0.01s     2.3 MB/sec    1.00      16.7±0.04s     2.3 MB/sec
concurrent/gbit-lan/#streams1/#messages1             1.02    126.8±2.30µs    30.8 MB/sec    1.00    124.2±1.04µs    31.4 MB/sec
concurrent/gbit-lan/#streams1/#messages10            1.04   857.2±77.05µs    45.6 MB/sec    1.00   827.7±16.55µs    47.2 MB/sec
concurrent/gbit-lan/#streams1/#messages100           1.01      7.9±0.29ms    49.5 MB/sec    1.00      7.8±0.07ms    50.0 MB/sec
concurrent/gbit-lan/#streams10/#messages1            1.02    831.7±6.08µs    47.0 MB/sec    1.00    815.3±4.09µs    47.9 MB/sec
concurrent/gbit-lan/#streams10/#messages10           1.01      7.8±0.12ms    50.1 MB/sec    1.00      7.7±0.07ms    50.4 MB/sec
concurrent/gbit-lan/#streams10/#messages100          1.00     75.3±0.79ms    51.9 MB/sec    1.00     75.2±0.50ms    51.9 MB/sec
concurrent/gbit-lan/#streams100/#messages1           1.00      7.9±0.16ms    49.7 MB/sec    1.01      7.9±0.18ms    49.2 MB/sec
concurrent/gbit-lan/#streams100/#messages10          1.01     77.8±2.00ms    50.2 MB/sec    1.00     77.1±0.49ms    50.7 MB/sec
concurrent/gbit-lan/#streams100/#messages100         1.00   773.2±15.14ms    50.5 MB/sec    1.00    771.9±4.28ms    50.6 MB/sec
concurrent/mobile/#streams1/#messages1               1.00     50.5±0.30ms    79.3 KB/sec    1.00     50.3±0.07ms    79.5 KB/sec
concurrent/mobile/#streams1/#messages10              1.00    100.6±0.09ms   397.4 KB/sec    1.00    100.7±0.10ms   397.4 KB/sec
concurrent/mobile/#streams1/#messages100             1.00    653.4±0.32ms   612.1 KB/sec    1.00    653.0±0.46ms   612.6 KB/sec
concurrent/mobile/#streams10/#messages1              1.00    100.7±0.08ms   397.2 KB/sec    1.00    100.7±0.04ms   397.2 KB/sec
concurrent/mobile/#streams10/#messages10             1.00    553.4±0.32ms   722.9 KB/sec    1.00    554.3±1.31ms   721.6 KB/sec
concurrent/mobile/#streams10/#messages100            1.00       5.5±0.00s   723.1 KB/sec    1.00       5.5±0.00s   723.3 KB/sec
concurrent/mobile/#streams100/#messages1             1.00    554.0±0.34ms   722.1 KB/sec    1.00    553.7±0.35ms   722.5 KB/sec
concurrent/mobile/#streams100/#messages10            1.00       5.5±0.00s   723.1 KB/sec    1.00       5.5±0.01s   722.9 KB/sec
concurrent/mobile/#streams100/#messages100           1.00      55.1±0.02s   725.7 KB/sec    1.00      55.2±0.08s   725.2 KB/sec
concurrent/unconstrained/#streams1/#messages1        1.00     38.6±1.15µs   101.2 MB/sec    1.00     38.7±1.36µs   100.9 MB/sec
concurrent/unconstrained/#streams1/#messages10       1.00    131.2±2.80µs   297.7 MB/sec    1.03    134.8±8.17µs   289.7 MB/sec
concurrent/unconstrained/#streams1/#messages100      1.00  1067.1±67.74µs   366.1 MB/sec    1.06  1132.5±104.27µs   344.9 MB/sec
concurrent/unconstrained/#streams10/#messages1       1.01   254.2±18.23µs   153.7 MB/sec    1.00    251.6±5.78µs   155.3 MB/sec
concurrent/unconstrained/#streams10/#messages10      1.08  1491.8±76.80µs   261.9 MB/sec    1.00  1380.7±47.10µs   282.9 MB/sec
concurrent/unconstrained/#streams10/#messages100     1.00     13.0±0.58ms   300.8 MB/sec    1.03     13.4±0.95ms   292.5 MB/sec
concurrent/unconstrained/#streams100/#messages1      1.35      2.6±0.27ms   148.1 MB/sec    1.00  1947.3±51.61µs   200.6 MB/sec
concurrent/unconstrained/#streams100/#messages10     1.09     14.6±0.47ms   268.2 MB/sec    1.00     13.3±0.21ms   292.6 MB/sec
concurrent/unconstrained/#streams100/#messages100    1.10    141.9±7.09ms   275.2 MB/sec    1.00    128.4±3.47ms   304.1 MB/sec
```