### PR TITLE
[tests] Add a test for a potential write deadlock.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ static_assertions = "1"
 [dev-dependencies]
 anyhow = "1"
 criterion = "0.3"
+env_logger = "0.6"
 futures = "0.3.4"
 quickcheck = "0.9"
-tokio = { version = "0.2", features = ["tcp", "rt-threaded", "macros"] }
-tokio-util = { version = "0.3", features = ["compat"] }
+tokio = { version = "1.0", features = ["net", "rt-multi-thread", "macros", "time"] }
+tokio-util = { version = "0.6", features = ["compat"] }
 constrained-connection = "0.1"
 
 [[bench]]

--- a/benches/concurrent.rs
+++ b/benches/concurrent.rs
@@ -43,7 +43,7 @@ fn concurrent(c: &mut Criterion) {
         for nstreams in [1, 10, 100].iter() {
             for nmessages in [1, 10, 100].iter() {
                 let data = data.clone();
-                let mut rt = Runtime::new().unwrap();
+                let rt = Runtime::new().unwrap();
 
                 group.throughput(Throughput::Bytes((nstreams * nmessages * data.0.len()) as u64));
                 group.bench_function(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -209,6 +209,8 @@ fn prop_send_recv_half_closed() {
 /// This test simulates two endpoints of a Yamux connection which may be unable to
 /// write simultaneously but can make progress by reading. If both endpoints
 /// don't read in-between trying to finish their writes, a deadlock occurs.
+//
+// Ignored for now as the current implementation is prone to the deadlock tested below.
 #[test]
 #[ignore]
 fn write_deadlock() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -257,12 +257,8 @@ fn write_deadlock() {
         }).boxed().into()
     ).unwrap();
 
-    // Handles to tasks on which to wait for completion.
-    let mut handles = Vec::new();
-
     // Send the message, expecting it to be echo'd.
-    let msg = msg.clone();
-    handles.push(pool.spawner().spawn_with_handle(async move {
+    pool.run_until(pool.spawner().spawn_with_handle(async move {
         let stream = ctrl.open_stream().await.unwrap();
         let (mut reader, mut writer) = AsyncReadExt::split(stream);
         let mut b = vec![0; msg.len()];
@@ -278,11 +274,6 @@ fn write_deadlock() {
         log::debug!("C: Stream {} done.", stream.id());
         assert_eq!(b, msg);
     }.boxed()).unwrap());
-
-    // Wait for completion.
-    for h in handles {
-        pool.run_until(h);
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,18 +16,25 @@ use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rand::Rng;
 use std::{fmt::Debug, io, net::{Ipv4Addr, SocketAddr, SocketAddrV4}};
 use tokio::{net::{TcpStream, TcpListener}, runtime::Runtime, task};
-use tokio_util::compat::{Compat, Tokio02AsyncReadCompatExt};
+use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+use futures::channel::mpsc::{unbounded, UnboundedSender, UnboundedReceiver};
+use futures::executor::LocalPool;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::pin::Pin;
+use futures::future::join;
+use futures::task::{Spawn, SpawnExt};
 
 #[test]
 fn prop_config_send_recv_single() {
     fn prop(mut msgs: Vec<Msg>, cfg1: TestConfig, cfg2: TestConfig) -> TestResult {
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
         msgs.insert(0, Msg(vec![1u8; crate::DEFAULT_CREDIT as usize]));
         rt.block_on(async move {
             let num_requests = msgs.len();
             let iter = msgs.into_iter().map(|m| m.0);
 
-            let (mut listener, address) = bind().await.expect("bind");
+            let (listener, address) = bind().await.expect("bind");
 
             let server = async {
                 let socket = listener.accept().await.expect("accept").0.compat();
@@ -53,13 +60,13 @@ fn prop_config_send_recv_single() {
 #[test]
 fn prop_config_send_recv_multi() {
     fn prop(mut msgs: Vec<Msg>, cfg1: TestConfig, cfg2: TestConfig) -> TestResult {
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
         msgs.insert(0, Msg(vec![1u8; crate::DEFAULT_CREDIT as usize]));
         rt.block_on(async move {
             let num_requests = msgs.len();
             let iter = msgs.into_iter().map(|m| m.0);
 
-            let (mut listener, address) = bind().await.expect("bind");
+            let (listener, address) = bind().await.expect("bind");
 
             let server = async {
                 let socket = listener.accept().await.expect("accept").0.compat();
@@ -88,12 +95,12 @@ fn prop_send_recv() {
         if msgs.is_empty() {
             return TestResult::discard()
         }
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
         rt.block_on(async move {
             let num_requests = msgs.len();
             let iter = msgs.into_iter().map(|m| m.0);
 
-            let (mut listener, address) = bind().await.expect("bind");
+            let (listener, address) = bind().await.expect("bind");
 
             let server = async {
                 let socket = listener.accept().await.expect("accept").0.compat();
@@ -123,9 +130,9 @@ fn prop_max_streams() {
         let mut cfg = Config::default();
         cfg.set_max_num_streams(max_streams);
 
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
         rt.block_on(async move {
-            let (mut listener, address) = bind().await.expect("bind");
+            let (listener, address) = bind().await.expect("bind");
 
             let cfg_s = cfg.clone();
             let server = async move {
@@ -158,9 +165,9 @@ fn prop_max_streams() {
 fn prop_send_recv_half_closed() {
     fn prop(msg: Msg) {
         let msg_len = msg.0.len();
-        let mut rt = Runtime::new().unwrap();
+        let rt = Runtime::new().unwrap();
         rt.block_on(async move {
-            let (mut listener, address) = bind().await.expect("bind");
+            let (listener, address) = bind().await.expect("bind");
 
             // Server should be able to write on a stream shutdown by the client.
             let server = async {
@@ -197,6 +204,85 @@ fn prop_send_recv_half_closed() {
         })
     }
     QuickCheck::new().tests(7).quickcheck(prop as fn(_))
+}
+
+/// This test simulates two endpoints of a Yamux connection which may be unable to
+/// write simultaneously but can make progress by reading. If both endpoints
+/// don't read in-between trying to finish their writes, a deadlock occurs.
+#[test]
+#[ignore]
+fn write_deadlock() {
+    let _ = env_logger::try_init();
+    let mut pool = LocalPool::new();
+
+    // We make the message to transmit large enough s.t. the "server"
+    // is forced to start writing (i.e. echoing) the bytes before
+    // having read the entire payload.
+    let msg = vec![1u8; 1024 * 1024];
+
+    // Create a bounded channel representing the underlying "connection".
+    // Each endpoint gets a name and a bounded capacity for its outbound
+    // channel (which is the other's inbound channel).
+    let (server_endpoint, client_endpoint) = bounded::channel(("S", 1024), ("C", 1024));
+
+    // Create and spawn a "server" that echoes every message back to the client.
+    let server = Connection::new(server_endpoint, Config::default(), Mode::Server);
+    pool.spawner().spawn_obj(async move {
+        crate::into_stream(server).try_for_each_concurrent(
+            None, |mut stream| async move {
+                {
+                    let (mut r, mut w) = AsyncReadExt::split(&mut stream);
+                    // Write back the bytes received. This may buffer internally.
+                    futures::io::copy(&mut r, &mut w).await?;
+                }
+                log::debug!("S: stream {} done.", stream.id());
+                stream.close().await?;
+                Ok(())
+            })
+            .await
+            .expect("server failed")
+    }.boxed().into()).unwrap();
+
+    // Create and spawn a "client" that sends messages expected to be echoed
+    // by the server.
+    let client = Connection::new(client_endpoint, Config::default(), Mode::Client);
+    let mut ctrl = client.control();
+
+    // Continuously advance the Yamux connection of the client in a background task.
+    pool.spawner().spawn_obj(
+        crate::into_stream(client).for_each(|_| {
+            panic!("Unexpected inbound stream for client");
+            #[allow(unreachable_code)]
+            future::ready(())
+        }).boxed().into()
+    ).unwrap();
+
+    // Handles to tasks on which to wait for completion.
+    let mut handles = Vec::new();
+
+    // Send the message, expecting it to be echo'd.
+    let msg = msg.clone();
+    handles.push(pool.spawner().spawn_with_handle(async move {
+        let stream = ctrl.open_stream().await.unwrap();
+        let (mut reader, mut writer) = AsyncReadExt::split(stream);
+        let mut b = vec![0; msg.len()];
+        // Write & read concurrently, so that the client is able
+        // to start reading the echo'd bytes before it even finished
+        // sending them all.
+        let _ = join(
+            writer.write_all(msg.as_ref()).map_err(|e| panic!(e)),
+            reader.read_exact(&mut b[..]).map_err(|e| panic!(e)),
+        ).await;
+        let mut stream = reader.reunite(writer).unwrap();
+        stream.close().await.unwrap();
+        log::debug!("C: Stream {} done.", stream.id());
+        assert_eq!(b, msg);
+    }.boxed()).unwrap());
+
+    // Wait for completion.
+    for h in handles {
+        pool.run_until(h);
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -314,3 +400,125 @@ where
     Ok(result)
 }
 
+/// This module implements a duplex connection via channels with bounded
+/// capacities. The channels used for the implementation are unbounded
+/// as the operate at the granularity of variably-sized chunks of bytes
+/// (`Vec<u8>`), whereas the capacity bounds (i.e. max. number of bytes
+/// in transit in one direction) are enforced separately.
+mod bounded {
+    use super::*;
+    use futures::ready;
+    use std::io::{Error, ErrorKind, Result};
+
+    pub struct Endpoint {
+        name: &'static str,
+        capacity: usize,
+        send: UnboundedSender<Vec<u8>>,
+        send_guard: Arc<Mutex<ChannelGuard>>,
+        recv: UnboundedReceiver<Vec<u8>>,
+        recv_buf: Vec<u8>,
+        recv_guard: Arc<Mutex<ChannelGuard>>,
+    }
+
+    /// A `ChannelGuard` is used to enforce the maximum number of
+    /// bytes "in transit" across all chunks of an unbounded channel.
+    #[derive(Default)]
+    struct ChannelGuard {
+        size: usize,
+        waker: Option<Waker>,
+    }
+
+    pub fn channel(
+        (name_a, capacity_a): (&'static str, usize),
+        (name_b, capacity_b): (&'static str, usize)
+    ) -> (Endpoint, Endpoint) {
+        let (a_to_b_sender, a_to_b_receiver) = unbounded();
+        let (b_to_a_sender, b_to_a_receiver) = unbounded();
+
+        let a_to_b_guard = Arc::new(Mutex::new(ChannelGuard::default()));
+        let b_to_a_guard = Arc::new(Mutex::new(ChannelGuard::default()));
+
+        let a = Endpoint {
+            name: name_a,
+            capacity: capacity_a,
+            send: a_to_b_sender,
+            send_guard: a_to_b_guard.clone(),
+            recv: b_to_a_receiver,
+            recv_buf: Vec::new(),
+            recv_guard: b_to_a_guard.clone(),
+        };
+
+        let b = Endpoint {
+            name: name_b,
+            capacity: capacity_b,
+            send: b_to_a_sender,
+            send_guard: b_to_a_guard,
+            recv: a_to_b_receiver,
+            recv_buf: Vec::new(),
+            recv_guard: a_to_b_guard,
+        };
+
+        (a, b)
+    }
+
+    impl AsyncRead for Endpoint {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
+            if self.recv_buf.is_empty() {
+                match ready!(self.recv.poll_next_unpin(cx)) {
+                    Some(bytes) => { self.recv_buf = bytes; }
+                    None => return Poll::Ready(Ok(0))
+                }
+            }
+
+            let n = std::cmp::min(buf.len(), self.recv_buf.len());
+            buf[0..n].copy_from_slice(&self.recv_buf[0..n]);
+            self.recv_buf = self.recv_buf.split_off(n);
+
+            let mut guard = self.recv_guard.lock().unwrap();
+            if let Some(waker) = guard.waker.take() {
+                log::debug!("{}: read: notifying waker after read of {} bytes", self.name, n);
+                waker.wake();
+            }
+            guard.size -= n;
+
+            log::debug!("{}: read: channel: {}/{}", self.name, guard.size, self.capacity);
+
+            Poll::Ready(Ok(n))
+        }
+    }
+
+    impl AsyncWrite for Endpoint {
+        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+            debug_assert!(buf.len() > 0);
+            let mut guard = self.send_guard.lock().unwrap();
+            let n = std::cmp::min(self.capacity - guard.size, buf.len());
+            if n == 0 {
+                log::debug!("{}: write: channel full, registering waker", self.name);
+                guard.waker = Some(cx.waker().clone());
+                return Poll::Pending;
+            }
+
+            self.send.unbounded_send(buf[0..n].to_vec())
+                .map_err(|e| Error::new(ErrorKind::ConnectionAborted, e))?;
+
+            guard.size += n;
+            log::debug!("{}: write: channel: {}/{}", self.name, guard.size, self.capacity);
+
+            Poll::Ready(Ok(n))
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            ready!(self.send.poll_flush_unpin(cx)).unwrap();
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            ready!(self.send.poll_close_unpin(cx)).unwrap();
+            Poll::Ready(Ok(()))
+        }
+    }
+}

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -11,11 +11,11 @@
 use futures::{channel::mpsc, prelude::*};
 use std::{net::{Ipv4Addr, SocketAddr, SocketAddrV4}, sync::Arc};
 use tokio::{net::{TcpStream, TcpListener}, task};
-use tokio_util::compat::Tokio02AsyncReadCompatExt;
+use tokio_util::compat::TokioAsyncReadCompatExt;
 use yamux::{Config, Connection, Mode};
 
 async fn roundtrip(address: SocketAddr, nstreams: usize, data: Arc<Vec<u8>>) {
-    let mut listener = TcpListener::bind(&address).await.expect("bind");
+    let listener = TcpListener::bind(&address).await.expect("bind");
     let address = listener.local_addr().expect("local address");
 
     let server = async move {


### PR DESCRIPTION
See https://github.com/paritytech/yamux/pull/102 for the preceding discussion. This PR adds a test that provokes a deadlock between two endpoints both wanting to write but cannot (i.e. `Pending`), though each could allow the other to make progress by reading. The test is disabled for now, due to actually stalling. It can be run with
```
RUST_LOG=yamux=debug cargo test deadlock -- --ignored
```
The logs will end with (`S` is the "server" echoing what the client sends, `C` is the "client" sending data it expects to get back, the "channel" is the artificially bounded "network connection")
```
[2021-02-04T15:13:35Z DEBUG yamux::tests::bounded] S: write: channel full, registering waker
...
[2021-02-04T15:13:35Z DEBUG yamux::tests::bounded] C: write: channel full, registering waker
```
i.e. both sides want to be woken to continue writing but neither actually does wake the other by reading, though the Client should do so because it reads and writes concurrently in separate tasks, but the Yamux connection insists on `.await`ing the write before doing anything else.

Unless someone sees a fault in the test, the next step would be to prepare a patch. As for the likelihood of this situation occurring, I'm not sure. It seems it would only occur if both endpoints get `Poll::Pending` trying to write a frame for some substream simultaneously while at the same time only being able to continue writing when the remote "makes room" on the connection by reading, hence the deadlock.

As an aside, this PR updates `tokio` in the tests.
