### PR TITLE
src/connection: Send WindowUpdate message early

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -693,7 +693,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 shared.update_state(self.id, stream_id, State::RecvClosed);
             }
             let max_buffer_size = self.config.max_buffer_size;
-            if shared.buffer.len().map(move |n| n >= max_buffer_size).unwrap_or(true) {
+            if shared.buffer.len() >= max_buffer_size {
                 log::error!("{}/{}: buffer of stream grows beyond limit", self.id, stream_id);
                 let mut header = Header::data(stream_id, 0);
                 header.rst();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -658,7 +658,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 let sender = self.stream_sender.clone();
                 Stream::new(stream_id, self.id, config, credit, credit, sender)
             };
-            let window_update;
+            let mut window_update = None;
             {
                 let mut shared = stream.shared();
                 if is_finish {
@@ -666,16 +666,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 }
                 shared.window = shared.window.saturating_sub(frame.body_len());
                 shared.buffer.push(frame.into_body());
-                if !is_finish
-                    && shared.window == 0
-                    && self.config.window_update_mode == WindowUpdateMode::OnReceive
-                {
-                    shared.window = self.config.receive_window;
-                    let mut frame = Frame::window_update(stream_id, self.config.receive_window);
+
+                if let Some(credit) = shared.next_window_update() {
+                    shared.window += credit;
+                    let mut frame = Frame::window_update(stream_id, credit);
                     frame.header_mut().ack();
                     window_update = Some(frame)
-                } else {
-                    window_update = None
                 }
             }
             if window_update.is_none() {
@@ -706,12 +702,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
             if let Some(w) = shared.reader.take() {
                 w.wake()
             }
-            if !is_finish
-                && shared.window == 0
-                && self.config.window_update_mode == WindowUpdateMode::OnReceive
-            {
-                shared.window = self.config.receive_window;
-                let frame = Frame::window_update(stream_id, self.config.receive_window);
+            if let Some(credit) = shared.next_window_update() {
+                shared.window += credit;
+                let frame = Frame::window_update(stream_id, credit);
                 return Action::Update(frame)
             }
         } else if !is_finish {
@@ -781,10 +774,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
                 w.wake()
             }
         } else if !is_finish {
-            log::debug!("{}/{}: window update for unknown stream", self.id, stream_id);
-            let mut header = Header::data(stream_id, 0);
-            header.rst();
-            return Action::Reset(Frame::new(header))
+            log::debug!("{}/{}: window update for unknown stream, ignoring", self.id, stream_id);
         }
 
         Action::None
@@ -939,4 +929,3 @@ where
         }
     })
 }
-

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -713,11 +713,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
             }
         } else {
             log::debug!("{}/{}: data for unknown stream, ignoring", self.id, stream_id);
-            // Previous implementations would send back a stream reset when receiving a data frame
-            // on an unknown stream. There are multiple benign scenarios that can lead to this
-            // happening and where a stream reset would not be appropriate. One such case would be
-            // when still in the process of sending out a frame closing the stream, while the stream
-            // data structure itself has already been garbage collected.
+            // We do not consider this a protocol violation and thus do not send a stream reset
+            // because we may still be processing pending `StreamCommand`s of this stream that were
+            // sent before it has been dropped and "garbage collected". Such a stream reset would
+            // interfere with the frames that still need to be sent, causing premature stream
+            // termination for the remote.
             //
             // See https://github.com/paritytech/yamux/issues/110 for details.
         }
@@ -783,11 +783,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
             }
         } else {
             log::debug!("{}/{}: window update for unknown stream, ignoring", self.id, stream_id);
-            // Previous implementations would send back a stream reset when receiving a window
-            // update frame on an unknown stream. There are multiple benign scenarios that can lead
-            // to this happening and where a stream reset would not be appropriate. One such case
-            // would be when still in the process of sending out a frame closing the stream, while
-            // the stream data structure itself has already been garbage collected.
+            // We do not consider this a protocol violation and thus do not send a stream reset
+            // because we may still be processing pending `StreamCommand`s of this stream that were
+            // sent before it has been dropped and "garbage collected". Such a stream reset would
+            // interfere with the frames that still need to be sent, causing premature stream
+            // termination for the remote.
             //
             // See https://github.com/paritytech/yamux/issues/110 for details.
         }
@@ -806,11 +806,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Connection<T> {
             return Action::Ping(Frame::new(hdr))
         }
         log::debug!("{}/{}: ping for unknown stream", self.id, stream_id);
-        // Previous implementations would send back a stream reset when receiving a ping frame on
-        // an unknown stream. There are multiple benign scenarios that can lead to this happening
-        // and where a stream reset would not be appropriate. One such case would be when still in
-        // the process of sending out a frame closing the stream, while the stream data structure
-        // itself has already been garbage collected.
+        // We do not consider this a protocol violation and thus do not send a stream reset because
+        // we may still be processing pending `StreamCommand`s of this stream that were sent before
+        // it has been dropped and "garbage collected". Such a stream reset would interfere with the
+        // frames that still need to be sent, causing premature stream termination for the remote.
         //
         // See https://github.com/paritytech/yamux/issues/110 for details.
 

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -411,14 +411,16 @@ impl Shared {
 
         let new_credit = match self.config.window_update_mode {
             WindowUpdateMode::OnReceive => {
-                let bytes_received = self.config.receive_window - self.window;
+                debug_assert!(self.config.receive_window >= self.window);
+                let bytes_received = self.config.receive_window.saturating_sub(self.window);
                 bytes_received
             },
             WindowUpdateMode::OnRead => {
+                debug_assert!(self.config.receive_window >= self.window);
+                let bytes_received = self.config.receive_window.saturating_sub(self.window);
                 let buffer_len: u32 = self.buffer.len()
                     .and_then(|l| l.try_into().ok())
                     .unwrap_or(std::u32::MAX);
-                let bytes_received = self.config.receive_window - self.window;
                 let bytes_read = bytes_received.saturating_sub(buffer_len);
                 bytes_read
             }

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -428,9 +428,7 @@ impl Shared {
             WindowUpdateMode::OnRead => {
                 debug_assert!(self.config.receive_window >= self.window);
                 let bytes_received = self.config.receive_window.saturating_sub(self.window);
-                let buffer_len: u32 = self.buffer.len()
-                    .and_then(|l| l.try_into().ok())
-                    .unwrap_or(std::u32::MAX);
+                let buffer_len: u32 = self.buffer.len().try_into().unwrap_or(std::u32::MAX);
                 let bytes_read = bytes_received.saturating_sub(buffer_len);
                 bytes_read
             }


### PR DESCRIPTION
To prevent senders from being blocked every time they have sent
RECEIVE_WINDOW (e.g. 256 KB) number of bytes, waiting for a WindowUpdate
message granting further sending credit, this commit makes Yamux send a
WindowUpdate message once half or more of the window has been received
(and consumed in `WindowUpdateMode::OnRead`). Benchmarking shows that
sending WindowUpdate messages early prevents senders from being blocked
waiting for additional credit on common network types.

For a detailed discussion as well as various benchmark results see
https://github.com/paritytech/yamux/issues/100.

Next to the above, this commit includes the following changes:

- Use `WindowUpdateMode::OnRead` in benchmarks. I would argue that
`OnRead` should be the default setting, given the importance of
flow-control. With that in mind, I suggest to benchmark that default
case.

- Ignore WindowUpdate messages for unknown streams. With this commit
WindowUpdate messages are sent more agressively. The following scenario
would surface: A sender would close its channel, eventually being
garbage collected. The receiver, before receiving the closing message,
sends out a WindowUpdate message. The sender receives the WindowUpdate
message not being able to associate it to a stream, thus resetting the
whole connection. This commit ignores WindowUpdate messages for unknown
streams instead.

When sending very large messages, WindowUpdate messages are still not
returned to the sender in time, thus the sender still being blocked in
such case. This can be prevented by splitting large messages into
smaller Yamux frames, see
https://github.com/paritytech/yamux/issues/100#issuecomment-774461550.
This additional optimization can be done in a future commit without
interfering with the optimization introduced in this commit.