### PR TITLE
Allow reads concurrent to pending writes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ static_assertions = "1"
 anyhow = "1"
 criterion = "0.3"
 futures = "0.3.4"
-quickcheck = "0.9"
+quickcheck = "1.0"
 tokio = { version = "0.2", features = ["tcp", "rt-threaded", "macros"] }
 tokio-util = { version = "0.3", features = ["compat"] }
 constrained-connection = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-futures = { version = "0.3.4", default-features = false, features = ["std"] }
+futures = { version = "0.3.12", default-features = false, features = ["std"] }
 log = "0.4.8"
 nohash-hasher = "0.2"
 parking_lot = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = { version = "0.3.4", default-features = false, features = ["std"] }
 log = "0.4.8"
 nohash-hasher = "0.2"
 parking_lot = "0.11"
-rand = "0.7.2"
+rand = "0.8.3"
 static_assertions = "1"
 
 [dev-dependencies]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -15,7 +15,7 @@ use futures::future::Either;
 use header::{Header, StreamId, Data, WindowUpdate, GoAway, Ping};
 use std::{convert::TryInto, num::TryFromIntError};
 
-pub(crate) use io::{Io, PollSend};
+pub(crate) use io::Io;
 pub use io::FrameDecodeError;
 
 /// A Yamux message frame consisting of header and body.

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -15,7 +15,7 @@ use futures::future::Either;
 use header::{Header, StreamId, Data, WindowUpdate, GoAway, Ping};
 use std::{convert::TryInto, num::TryFromIntError};
 
-pub(crate) use io::Io;
+pub(crate) use io::{Io, PollSend};
 pub use io::FrameDecodeError;
 
 /// A Yamux message frame consisting of header and body.
@@ -46,6 +46,15 @@ impl<T> Frame<T> {
     /// Introduce this frame to the left of a binary frame type.
     pub(crate) fn left<U>(self) -> Frame<Either<T, U>> {
         Frame { header: self.header.left(), body: self.body }
+    }
+}
+
+impl<A: header::private::Sealed> From<Frame<A>> for Frame<()> {
+    fn from(f: Frame<A>) -> Frame<()> {
+        Frame {
+            header: f.header.into(),
+            body: f.body
+        }
     }
 }
 
@@ -117,4 +126,3 @@ impl Frame<GoAway> {
         }
     }
 }
-

--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -406,22 +406,19 @@ impl std::error::Error for HeaderDecodeError {}
 #[cfg(test)]
 mod tests {
     use quickcheck::{Arbitrary, Gen, QuickCheck};
-    use rand::{Rng, seq::SliceRandom};
     use super::*;
 
     impl Arbitrary for Header<()> {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
-            let tag = [Tag::Data, Tag::WindowUpdate, Tag::Ping, Tag::GoAway]
-                .choose(g)
-                .unwrap()
-                .clone();
+        fn arbitrary(g: &mut Gen) -> Self {
+            let tag = *g.choose(&[Tag::Data, Tag::WindowUpdate, Tag::Ping, Tag::GoAway])
+                .unwrap();
 
             Header {
                 version: Version(0),
                 tag,
-                flags: Flags(g.gen()),
-                stream_id: StreamId(g.gen()),
-                length: Len(g.gen()),
+                flags: Flags(Arbitrary::arbitrary(g)),
+                stream_id: StreamId(Arbitrary::arbitrary(g)),
+                length: Len(Arbitrary::arbitrary(g)),
                 _marker: std::marker::PhantomData
             }
         }

--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -77,6 +77,12 @@ impl<T> Header<T> {
     }
 }
 
+impl<A: private::Sealed> From<Header<A>> for Header<()> {
+    fn from(h: Header<A>) -> Header<()> {
+        h.cast()
+    }
+}
+
 impl Header<()> {
     pub(crate) fn into_data(self) -> Header<Data> {
         debug_assert_eq!(self.tag, Tag::Data);
@@ -242,12 +248,13 @@ pub trait HasRst: private::Sealed {}
 impl HasRst for Data {}
 impl HasRst for WindowUpdate {}
 
-mod private {
+pub(super) mod private {
     pub trait Sealed {}
 
     impl Sealed for super::Data {}
     impl Sealed for super::WindowUpdate {}
     impl Sealed for super::Ping {}
+    impl Sealed for super::GoAway {}
     impl<A: Sealed, B: Sealed> Sealed for super::Either<A, B> {}
 }
 

--- a/src/frame/io.rs
+++ b/src/frame/io.rs
@@ -214,7 +214,7 @@ mod tests {
     use super::*;
 
     impl Arbitrary for Frame<()> {
-        fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        fn arbitrary(g: &mut Gen) -> Self {
             let mut header: header::Header<()> = Arbitrary::arbitrary(g);
             let body =
                 if header.tag() == header::Tag::Data {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -211,7 +211,6 @@ fn prop_send_recv_half_closed() {
 //
 // Ignored for now as the current implementation is prone to the deadlock tested below.
 #[test]
-#[ignore]
 fn write_deadlock() {
     let _ = env_logger::try_init();
     let mut pool = LocalPool::new();
@@ -219,12 +218,21 @@ fn write_deadlock() {
     // We make the message to transmit large enough s.t. the "server"
     // is forced to start writing (i.e. echoing) the bytes before
     // having read the entire payload.
-    let msg = vec![1u8; 1024 * 1024];
+    let msg = vec![1u8; 1 * 1024 * 1024];
+
+    // We choose a "connection capacity" that is artificially below
+    // the size of a receive window. If it were equal or greater,
+    // multiple concurrently writing streams would be needed to non-deterministically
+    // provoke the write deadlock. This is supposed to reflect the
+    // fact that the sum of receive windows of all open streams can easily
+    // be larger than the send capacity of the connection at any point in time.
+    // Using such a low capacity here therefore yields a more reproducible test.
+    let capacity = 1024;
 
     // Create a bounded channel representing the underlying "connection".
     // Each endpoint gets a name and a bounded capacity for its outbound
     // channel (which is the other's inbound channel).
-    let (server_endpoint, client_endpoint) = bounded::channel(("S", 1024), ("C", 1024));
+    let (server_endpoint, client_endpoint) = bounded::channel(("S", capacity), ("C", capacity));
 
     // Create and spawn a "server" that echoes every message back to the client.
     let server = Connection::new(server_endpoint, Config::default(), Mode::Server);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -218,7 +218,7 @@ fn write_deadlock() {
     // We make the message to transmit large enough s.t. the "server"
     // is forced to start writing (i.e. echoing) the bytes before
     // having read the entire payload.
-    let msg = vec![1u8; 1 * 1024 * 1024];
+    let msg = vec![1u8; 1024 * 1024];
 
     // We choose a "connection capacity" that is artificially below
     // the size of a receive window. If it were equal or greater,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,6 @@ use crate::WindowUpdateMode;
 use futures::{future, prelude::*};
 use futures::io::AsyncReadExt;
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
-use rand::Rng;
 use std::{fmt::Debug, io, net::{Ipv4Addr, SocketAddr, SocketAddrV4}};
 use tokio::{net::{TcpStream, TcpListener}, runtime::Runtime, task};
 use tokio_util::compat::{Compat, Tokio02AsyncReadCompatExt};
@@ -203,11 +202,17 @@ fn prop_send_recv_half_closed() {
 struct Msg(Vec<u8>);
 
 impl Arbitrary for Msg {
-    fn arbitrary<G: Gen>(g: &mut G) -> Msg {
-        let n: usize = g.gen_range(1, g.size() + 1);
-        let mut v = vec![0; n];
-        g.fill(&mut v[..]);
-        Msg(v)
+    fn arbitrary(g: &mut Gen) -> Msg {
+        let mut msg = Msg(Arbitrary::arbitrary(g));
+        if msg.0.is_empty() {
+            msg.0.push(Arbitrary::arbitrary(g));
+        }
+
+        msg
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+        Box::new(self.0.shrink().filter(|v| !v.is_empty()).map(|v| Msg(v)))
     }
 }
 
@@ -215,15 +220,15 @@ impl Arbitrary for Msg {
 struct TestConfig(Config);
 
 impl Arbitrary for TestConfig {
-    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+    fn arbitrary(g: &mut Gen) -> Self {
         let mut c = Config::default();
-        c.set_window_update_mode(if g.gen() {
+        c.set_window_update_mode(if bool::arbitrary(g) {
             WindowUpdateMode::OnRead
         } else {
             WindowUpdateMode::OnReceive
         });
-        c.set_read_after_close(g.gen());
-        c.set_receive_window(g.gen_range(256 * 1024, 1024 * 1024));
+        c.set_read_after_close(Arbitrary::arbitrary(g));
+        c.set_receive_window(256 * 1024 + u32::arbitrary(g) % (768 * 1024));
         TestConfig(c)
     }
 }

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -69,7 +69,7 @@ async fn roundtrip(address: SocketAddr, nstreams: usize, data: Arc<Vec<u8>>) {
 #[tokio::test]
 async fn concurrent_streams() {
     let _ = env_logger::try_init();
-    let data = Arc::new(vec![0x42; 100 * 1024]);
+    let data = Arc::new(vec![0x42; 1024 * 1024]);
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
     roundtrip(addr, 1000, data).await
 }

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -68,6 +68,7 @@ async fn roundtrip(address: SocketAddr, nstreams: usize, data: Arc<Vec<u8>>) {
 
 #[tokio::test]
 async fn concurrent_streams() {
+    let _ = env_logger::try_init();
     let data = Arc::new(vec![0x42; 100 * 1024]);
     let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
     roundtrip(addr, 1000, data).await

--- a/tests/concurrent.rs
+++ b/tests/concurrent.rs
@@ -20,7 +20,7 @@ async fn roundtrip(
     address: SocketAddr,
     nstreams: usize,
     data: Arc<Vec<u8>>,
-    tcp_buffer_sizes: Option<TcpBuferSizes>,
+    tcp_buffer_sizes: Option<TcpBufferSizes>,
 ) {
     let listener = {
         let socket = TcpSocket::new_v4().expect("new_v4");
@@ -103,12 +103,12 @@ async fn roundtrip(
 
 /// Send and receive buffer size for a TCP socket.
 #[derive(Clone, Debug, Copy)]
-struct TcpBuferSizes {
+struct TcpBufferSizes {
     send: u32,
     recv: u32,
 }
 
-impl Arbitrary for TcpBuferSizes {
+impl Arbitrary for TcpBufferSizes {
     fn arbitrary(g: &mut Gen) -> Self {
         let send = if bool::arbitrary(g) {
             16*1024
@@ -123,7 +123,7 @@ impl Arbitrary for TcpBuferSizes {
             send * 4
         };
 
-        TcpBuferSizes { send, recv }
+        TcpBufferSizes { send, recv }
     }
 }
 
@@ -131,12 +131,12 @@ impl Arbitrary for TcpBuferSizes {
 fn concurrent_streams() {
     let _ = env_logger::try_init();
 
-    fn prop (tcp_buffer_sizes: Option<TcpBuferSizes>) {
+    fn prop(tcp_buffer_sizes: Option<TcpBufferSizes>) {
         let data = Arc::new(vec![0x42; PAYLOAD_SIZE]);
         let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
 
         Runtime::new().expect("new runtime").block_on(roundtrip(addr, 1000, data, tcp_buffer_sizes));
     }
 
-    QuickCheck::new().tests(1).quickcheck(prop as fn(_) -> _)
+    QuickCheck::new().tests(3).quickcheck(prop as fn(_) -> _)
 }


### PR DESCRIPTION
Currently, all write operations (e.g. for a particular frame sent by a substream) are `.await`ed for completion within the `Connection::next()` loop, thus prohibiting reading from the underlying socket while the write is pending. This can lead to unexpected write deadlocks between two peers in specific, though likely uncommon, situations. See  https://github.com/paritytech/yamux/pull/104 for further details and a test.

This PR proposes to allow concurrent reads while a frame write is pending, thereby propagating pending write back-pressure via the paused command channels, rather than doing so by "blocking"`Connection::next()` entirely until such a write completes.

Notably, no new buffers are introduced. We still send one frame at a time from the context of a `Connection`. However, when a frame write cannot complete, the command channels are paused and I/O reads can continue while the write is pending. The paused command channels exercise write back-pressure on the streams and API and ensure that the only frames we still try to send are those as a result of reading a frame - these writes then indeed wait for completion of the prior pending send operation, if any, but since it is done as a result of reading a frame, the remote can in turn usually write again, should it have been waiting to be able to do so before it in turn can read again. Unexpected write deadlocks of peers which otherwise appear to read & write concurrently from substreams can thus be avoided. I'm not entirely sure if there may not still be situations where a write deadlock can be provoked but I did not want to introduce new "pending frames" buffers, which would again be bounded and raise the question of what to do when these are also full. I thus came up with this "refinement" of the status quo without new buffers.

The previously ignored test introduced in #104 is hereby enabled.