### PR TITLE
Prepare v0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.9.0
+
+- Force-split larger frames, for better interleaving of
+  reads and writes between different substreams and to avoid
+  single, large writes. By default frames are capped at, and
+  thus split at, `16KiB`, which can be adjusted by a new
+  configuration option, if necessary.
+
+- Send window updates earlier, when half of the window has
+  been consumed, to minimise pauses due to transmission delays,
+  particularly if there is just a single dominant substream.
+
+- Avoid possible premature stream resets of streams that
+  have been properly closed and already dropped but receive
+  window update or other frames while the remaining buffered
+  frames are still sent out. Incoming frames for unknown streams
+  are now ignored, instead of triggering a stream reset for the
+  remote.
+
 # 0.8.0
 
 - Upgrade step 4 of 4. This version always assumes the new semantics and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"


### PR DESCRIPTION
This PR prepares the release of `v0.9`. A merge of this PR to `develop` will be followed up with a merge of `develop` into `master` for the release.