### PR TITLE
v0.8.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop, master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.8.1
+
+- Avoid possible premature stream resets of streams that have been properly
+  closed and already dropped but receive window update or other frames while
+  the remaining buffered frames are still sent out. Incoming frames for
+  unknown streams are now ignored, instead of triggering a stream reset for
+  the remote.
+
 # 0.8.0
 
 - Upgrade step 4 of 4. This version always assumes the new semantics and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yamux"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Multiplexer over reliable, ordered connections"


### PR DESCRIPTION
To avoid surprises, it seems best to backport the part of `v0.9` that ignores received frames for unknown streams into a `v0.8.1` release. Otherwise nodes running `v0.8` may react with a stream reset if they get a window update from a node running `v0.9` while the stream is already closing. Rolling out `v0.8.1` first should avoid such hiccups.

cc @mxinden 